### PR TITLE
ci: trigger language specific ci only when that language's code changes (#9)

### DIFF
--- a/.github/workflows/c-build.yml
+++ b/.github/workflows/c-build.yml
@@ -1,14 +1,10 @@
 name: C Build & Test
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'implementations/c/**'
   pull_request:
-    branches: [main]
     paths:
       - 'implementations/c/**'
+      - '.github/workflows/c-build.yml'
 
 jobs:
   build-and-test:

--- a/.github/workflows/misra.yml
+++ b/.github/workflows/misra.yml
@@ -1,14 +1,10 @@
 name: MISRA-C Compliance
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'implementations/c/**'
   pull_request:
-    branches: [main]
     paths:
       - 'implementations/c/**'
+      - '.github/workflows/misra.yml'
 
 jobs:
   misra-check:


### PR DESCRIPTION
All workflows now trigger only on pull_request with path-based filters:
- c-build.yml: implementations/c/**
- misra.yml: implementations/c/**
- python-build.yml: implementations/python/**
- micropython-build.yml: implementations/python/**

🤖 Generated with [Claude Code](https://claude.com/claude-code)