### PR TITLE
docs: rename report files to index.html for cleaner URLs (#39)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
           make test 2>&1 | tee build/test-output.txt
 
           # Generate HTML test report
-          cat > build/docs/tests/report.html << 'HTMLEOF'
+          cat > build/docs/tests/index.html << 'HTMLEOF'
           <!DOCTYPE html>
           <html lang="en">
           <head>
@@ -70,12 +70,12 @@ jobs:
             # Check for suite header (line followed by ===)
             if [[ "$line" =~ ^[A-Z] ]] && [[ ! "$line" =~ "Running" ]] && [[ ! "$line" =~ "tests passed" ]]; then
               if [[ "$current_suite" != "" ]]; then
-                echo '</div>' >> build/docs/tests/report.html
+                echo '</div>' >> build/docs/tests/index.html
               fi
               suite_name=$(echo "$line" | sed 's/Tests$//' | sed 's/:$//')
               if [[ "$suite_name" != "" ]] && [[ ! "$suite_name" =~ "=" ]]; then
                 current_suite="$suite_name"
-                echo "<div class=\"suite\"><h2>$suite_name</h2>" >> build/docs/tests/report.html
+                echo "<div class=\"suite\"><h2>$suite_name</h2>" >> build/docs/tests/index.html
               fi
             fi
 
@@ -83,9 +83,9 @@ jobs:
             if [[ "$line" =~ "test_" ]]; then
               test_name=$(echo "$line" | sed 's/^[[:space:]]*//' | sed 's/\.\.\..*//')
               if [[ "$line" =~ "✓" ]]; then
-                echo "<div class=\"test pass\">$test_name</div>" >> build/docs/tests/report.html
+                echo "<div class=\"test pass\">$test_name</div>" >> build/docs/tests/index.html
               elif [[ "$line" =~ "✗" ]]; then
-                echo "<div class=\"test fail\">$test_name</div>" >> build/docs/tests/report.html
+                echo "<div class=\"test fail\">$test_name</div>" >> build/docs/tests/index.html
               fi
             fi
 
@@ -95,13 +95,13 @@ jobs:
               tests="${BASH_REMATCH[2]}"
               total_passed=$((total_passed + passed))
               total_tests=$((total_tests + tests))
-              echo "<div class=\"stats\">$passed/$tests tests passed</div>" >> build/docs/tests/report.html
+              echo "<div class=\"stats\">$passed/$tests tests passed</div>" >> build/docs/tests/index.html
             fi
           done < build/test-output.txt
 
           # Close last suite
           if [[ "$current_suite" != "" ]]; then
-            echo '</div>' >> build/docs/tests/report.html
+            echo '</div>' >> build/docs/tests/index.html
           fi
 
           # Add summary
@@ -111,7 +111,7 @@ jobs:
             summary_class="summary fail"
           fi
 
-          cat >> build/docs/tests/report.html << HTMLEOF
+          cat >> build/docs/tests/index.html << HTMLEOF
             <div class="$summary_class">
               <strong>Total: $total_passed/$total_tests tests passed</strong>
             </div>
@@ -160,7 +160,7 @@ jobs:
           ./build/tests 2>&1 | tee build/test-output.txt
 
           # Generate HTML test report
-          cat > build/docs/tests/report.html << 'HTMLEOF'
+          cat > build/docs/tests/index.html << 'HTMLEOF'
           <!DOCTYPE html>
           <html lang="en">
           <head>
@@ -183,16 +183,16 @@ jobs:
           if grep -q "All tests passed" build/test-output.txt; then
             PASSED=$(grep -oE "[0-9]+ assertions" build/test-output.txt | head -1 | grep -oE "[0-9]+")
             TESTS=$(grep -oE "[0-9]+ test cases" build/test-output.txt | head -1 | grep -oE "[0-9]+")
-            echo "<div class=\"summary\"><strong>All $TESTS test cases passed ($PASSED assertions)</strong></div>" >> build/docs/tests/report.html
+            echo "<div class=\"summary\"><strong>All $TESTS test cases passed ($PASSED assertions)</strong></div>" >> build/docs/tests/index.html
           else
-            echo "<div class=\"summary fail\"><strong>Some tests failed</strong></div>" >> build/docs/tests/report.html
+            echo "<div class=\"summary fail\"><strong>Some tests failed</strong></div>" >> build/docs/tests/index.html
           fi
 
-          echo "<h2>Full Output</h2><pre>" >> build/docs/tests/report.html
-          cat build/test-output.txt >> build/docs/tests/report.html
-          echo "</pre>" >> build/docs/tests/report.html
-          echo "<p style=\"color: #666; font-size: 0.8rem;\">Generated on $(date -u '+%Y-%m-%d %H:%M:%S UTC')</p>" >> build/docs/tests/report.html
-          echo "</body></html>" >> build/docs/tests/report.html
+          echo "<h2>Full Output</h2><pre>" >> build/docs/tests/index.html
+          cat build/test-output.txt >> build/docs/tests/index.html
+          echo "</pre>" >> build/docs/tests/index.html
+          echo "<p style=\"color: #666; font-size: 0.8rem;\">Generated on $(date -u '+%Y-%m-%d %H:%M:%S UTC')</p>" >> build/docs/tests/index.html
+          echo "</body></html>" >> build/docs/tests/index.html
 
       - name: Generate coverage HTML
         working-directory: implementations/cpp
@@ -254,7 +254,7 @@ jobs:
           mkdir -p build/docs
           pytest -v --fast --cov=pocketplus \
             --cov-report=html:build/docs/coverage \
-            --html=build/docs/tests/report.html --self-contained-html
+            --html=build/docs/tests/index.html --self-contained-html
 
       - name: Generate API docs
         working-directory: implementations/python
@@ -288,7 +288,7 @@ jobs:
         run: |
           mkdir -p build/docs/tests
           go test -v ./pocketplus/ 2>&1 | tee build/test-output.txt
-          ./scripts/generate-test-report.sh build/test-output.txt build/docs/tests/report.html
+          ./scripts/generate-test-report.sh build/test-output.txt build/docs/tests/index.html
 
       - name: Generate coverage HTML
         working-directory: implementations/go
@@ -332,13 +332,14 @@ jobs:
         run: |
           mkdir -p build/docs/tests
           cargo test --release 2>&1 | tee build/test-output.txt
-          ./scripts/generate-test-report.sh build/test-output.txt build/docs/tests/report.html
+          ./scripts/generate-test-report.sh build/test-output.txt build/docs/tests/index.html
 
       - name: Generate coverage HTML
         working-directory: implementations/rust
         run: |
           mkdir -p build/docs/coverage
           cargo tarpaulin --out Html --output-dir build/docs/coverage
+          mv build/docs/coverage/tarpaulin-report.html build/docs/coverage/index.html
 
       - name: Generate API docs
         working-directory: implementations/rust

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,7 +100,7 @@
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/c">Source</a>
           <a href="c/api/">API</a><br>
           <a href="c/coverage/">Coverage</a>
-          <a href="c/tests/report.html">Tests</a>
+          <a href="c/tests/">Tests</a>
         </div>
       </div>
 
@@ -110,7 +110,7 @@
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/cpp">Source</a>
           <a href="cpp/api/">API</a><br>
           <a href="cpp/coverage/">Coverage</a>
-          <a href="cpp/tests/report.html">Tests</a>
+          <a href="cpp/tests/">Tests</a>
         </div>
       </div>
 
@@ -120,7 +120,7 @@
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/go">Source</a>
           <a href="go/api/">API</a><br>
           <a href="go/coverage/">Coverage</a>
-          <a href="go/tests/report.html">Tests</a>
+          <a href="go/tests/">Tests</a>
         </div>
       </div>
 
@@ -130,7 +130,7 @@
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/python">Source</a>
           <a href="python/api/">API</a><br>
           <a href="python/coverage/">Coverage</a>
-          <a href="python/tests/report.html">Tests</a>
+          <a href="python/tests/">Tests</a>
         </div>
       </div>
 
@@ -139,8 +139,8 @@
         <div class="impl-links">
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/rust">Source</a>
           <a href="rust/api/pocketplus/">API</a><br>
-          <a href="rust/coverage/tarpaulin-report.html">Coverage</a>
-          <a href="rust/tests/report.html">Tests</a>
+          <a href="rust/coverage/">Coverage</a>
+          <a href="rust/tests/">Tests</a>
         </div>
       </div>
 
@@ -150,7 +150,7 @@
           <a href="https://github.com/tanagraspace/pocket-plus/tree/main/implementations/java">Source</a>
           <a href="java/api/">API</a><br>
           <a href="java/coverage/">Coverage</a>
-          <a href="java/tests/report.html">Tests</a>
+          <a href="java/tests/">Tests</a>
         </div>
       </div>
     </div>

--- a/implementations/go/Makefile
+++ b/implementations/go/Makefile
@@ -23,7 +23,7 @@ test-report:
 	@echo "Running tests and generating report..."
 	@go test -v ./pocketplus/ 2>&1 | tee $(BUILD_DIR)/test-output.txt
 	@echo "Generating HTML report..."
-	@./scripts/generate-test-report.sh $(BUILD_DIR)/test-output.txt $(DOCS_DIR)/tests/report.html
+	@./scripts/generate-test-report.sh $(BUILD_DIR)/test-output.txt $(DOCS_DIR)/tests/index.html
 
 coverage:
 	mkdir -p $(BUILD_DIR)

--- a/implementations/python/Dockerfile
+++ b/implementations/python/Dockerfile
@@ -16,6 +16,6 @@ CMD ["sh", "-c", "\
     pytest -v --cov=pocketplus \
         --cov-report=html:build/docs/coverage \
         --cov-report=xml:build/docs/coverage.xml \
-        --html=build/docs/tests/report.html --self-contained-html && \
+        --html=build/docs/tests/index.html --self-contained-html && \
     pdoc -d google pocketplus -o build/docs/api \
 "]

--- a/implementations/rust/Makefile
+++ b/implementations/rust/Makefile
@@ -22,7 +22,7 @@ test-report:
 	@echo "Running tests and generating report..."
 	@cargo test --release 2>&1 | tee $(BUILD_DIR)/test-output.txt
 	@echo "Generating HTML report..."
-	@./scripts/generate-test-report.sh $(BUILD_DIR)/test-output.txt $(DOCS_DIR)/tests/report.html
+	@./scripts/generate-test-report.sh $(BUILD_DIR)/test-output.txt $(DOCS_DIR)/tests/index.html
 
 bench:
 	cargo build --release --bin bench
@@ -31,6 +31,7 @@ bench:
 coverage:
 	mkdir -p $(BUILD_DIR)/coverage
 	cargo tarpaulin --out Html --output-dir $(BUILD_DIR)/coverage
+	@mv $(BUILD_DIR)/coverage/tarpaulin-report.html $(BUILD_DIR)/coverage/index.html 2>/dev/null || true
 
 fmt:
 	cargo fmt


### PR DESCRIPTION
- Update Go Makefile test-report output to index.html
- Update Rust Makefile test-report output to index.html
- Update Rust coverage to rename tarpaulin-report.html to index.html
- Update Python Dockerfile pytest-html output to index.html
- Update pages.yml CI pipeline for all implementations
- Update landing page links to use directory URLs

Enables clean URL paths: /c/tests/ instead of /c/tests/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)