### PR TITLE
tests(python): increase unit test coverage (#27)

### DIFF
--- a/implementations/python/tests/test_bitvector.py
+++ b/implementations/python/tests/test_bitvector.py
@@ -177,6 +177,38 @@ class TestBitVectorBitwiseOps:
         for i in range(4):
             assert result.get_bit(i) == 0
 
+    def test_not_multi_byte_partial(self) -> None:
+        """Test NOT with multiple bytes where last byte is partial.
+
+        This tests the edge case in line 284 where we have multiple
+        bytes in the last word and need to mask properly.
+        """
+        # 12 bits = 1.5 bytes, spans into 2nd byte of a 32-bit word
+        a = BitVector(12)
+        a.from_bytes(bytes([0xFF, 0xF0]))  # All 1s in first 12 bits
+
+        result = a.not_()
+        # All 12 bits should be inverted to 0
+        for i in range(12):
+            assert result.get_bit(i) == 0
+
+    def test_not_exactly_two_bytes(self) -> None:
+        """Test NOT with exactly 16 bits (2 bytes)."""
+        a = BitVector(16)
+        a.from_bytes(bytes([0xFF, 0xFF]))
+
+        result = a.not_()
+        assert result.to_bytes() == bytes([0x00, 0x00])
+
+    def test_not_three_bytes_partial(self) -> None:
+        """Test NOT with 20 bits (2.5 bytes) to exercise middle byte path."""
+        a = BitVector(20)
+        a.from_bytes(bytes([0xFF, 0xFF, 0xF0]))  # All 1s in first 20 bits
+
+        result = a.not_()
+        for i in range(20):
+            assert result.get_bit(i) == 0
+
 
 class TestBitVectorLeftShift:
     """Test left shift operation."""

--- a/implementations/python/tests/test_decode.py
+++ b/implementations/python/tests/test_decode.py
@@ -3,8 +3,8 @@
 from pocketplus.bitbuffer import BitBuffer
 from pocketplus.bitreader import BitReader
 from pocketplus.bitvector import BitVector
-from pocketplus.decode import bit_insert, count_decode, rle_decode
-from pocketplus.encode import bit_extract, count_encode, rle_encode
+from pocketplus.decode import bit_insert, bit_insert_forward, count_decode, rle_decode
+from pocketplus.encode import bit_extract, bit_extract_forward, count_encode, rle_encode
 
 
 class TestCountDecode:
@@ -224,6 +224,85 @@ class TestRoundTrip:
         result = BitVector(16)
         reader = BitReader(bb.to_bytes())
         bit_insert(reader, result, mask)
+
+        # Check only masked positions match
+        for i in range(16):
+            if mask.get_bit(i):
+                assert result.get_bit(i) == data.get_bit(i)
+
+
+class TestBitInsertForward:
+    """Test forward bit insertion (for kt component)."""
+
+    def test_bit_insert_forward_no_mask(self) -> None:
+        """Test forward insertion with zero mask does nothing."""
+        data = BitVector(8)
+        mask = BitVector(8)
+
+        reader = BitReader(b"")
+        bit_insert_forward(reader, data, mask)
+
+        for i in range(8):
+            assert data.get_bit(i) == 0
+
+    def test_bit_insert_forward_full_mask(self) -> None:
+        """Test forward insertion with full mask."""
+        data = BitVector(8)
+        mask = BitVector(8)
+        mask.from_bytes(bytes([0xFF]))
+
+        original = bytes([0b10110100])
+        bv_orig = BitVector(8)
+        bv_orig.from_bytes(original)
+
+        # Extract bits in forward order
+        bb = BitBuffer()
+        bit_extract_forward(bb, bv_orig, mask)
+
+        # Insert back in forward order
+        reader = BitReader(bb.to_bytes())
+        bit_insert_forward(reader, data, mask)
+
+        # Should match original
+        assert data.to_bytes() == original
+
+    def test_bit_insert_forward_partial_mask(self) -> None:
+        """Test forward insertion with partial mask."""
+        data = BitVector(8)
+        mask = BitVector(8)
+        mask.from_bytes(bytes([0b10100000]))
+
+        original = BitVector(8)
+        original.from_bytes(bytes([0b11110000]))
+
+        # Extract bits at mask positions in forward order
+        bb = BitBuffer()
+        bit_extract_forward(bb, original, mask)
+
+        # Insert back in forward order
+        reader = BitReader(bb.to_bytes())
+        bit_insert_forward(reader, data, mask)
+
+        # Check only masked positions
+        assert data.get_bit(0) == original.get_bit(0)
+        assert data.get_bit(2) == original.get_bit(2)
+
+    def test_bit_extract_insert_forward_round_trip(self) -> None:
+        """Test forward extract/insert round trip."""
+        data = BitVector(16)
+        data.from_bytes(bytes([0xDE, 0xAD]))
+
+        mask = BitVector(16)
+        mask.from_bytes(bytes([0xAA, 0x55]))
+
+        # Extract in forward order
+        bb = BitBuffer()
+        bit_extract_forward(bb, data, mask)
+
+        # Create new vector and insert in forward order
+        result = BitVector(16)
+        reader = BitReader(bb.to_bytes())
+        bit_insert_forward(reader, result, mask)
 
         # Check only masked positions match
         for i in range(16):


### PR DESCRIPTION
- Add tests for COUNT encode error handling (out of range values)
- Add tests for bit_extract/bit_extract_forward length mismatch errors
- Add tests for BitVector NOT operation with multi-byte partial words
- Add tests for compress() with invalid input size
- Add tests for Compressor.compress_packet() with default params
- Add tests for effective robustness Vt capping at 15
- Add tests for bit_insert_forward function (kt component)
- Add tests for Vt=0 mask toggle behavior in decompression

Coverage improved from 98% to 99% (622 statements, 1 uncovered). The remaining uncovered line 383 is defensive dead code.

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)