### PR TITLE
ci: exclude benchmark and CLI code from coverage reports (#38)

### DIFF
--- a/implementations/c/Makefile
+++ b/implementations/c/Makefile
@@ -120,6 +120,8 @@ coverage-badge:
 	@mkdir -p assets
 	@# Generate coverage.info first for accurate stats
 	@lcov --capture --directory $(COV_DIR) --output-file $(COV_DIR)/coverage.info --include "*/src/*" 2>/dev/null || true
+	@# Exclude CLI from coverage (tested via integration tests, not unit tests)
+	@lcov --remove $(COV_DIR)/coverage.info '*/src/cli.c' --output-file $(COV_DIR)/coverage.info 2>/dev/null || true
 	@# Extract line and function coverage from lcov summary
 	@lcov --summary $(COV_DIR)/coverage.info 2>&1 | grep "lines" | sed 's/.*: //' | sed 's/%.*//' > $(COV_DIR)/.lines_pct
 	@lcov --summary $(COV_DIR)/coverage.info 2>&1 | grep "functions" | sed 's/.*: //' | sed 's/%.*//' > $(COV_DIR)/.funcs_pct
@@ -163,6 +165,7 @@ coverage-html:
 	@mkdir -p $(DOCS_DIR)/coverage/html
 	@if [ ! -f $(COV_DIR)/coverage.info ]; then \
 		lcov --capture --directory $(COV_DIR) --output-file $(COV_DIR)/coverage.info --include "*/src/*"; \
+		lcov --remove $(COV_DIR)/coverage.info '*/src/cli.c' --output-file $(COV_DIR)/coverage.info; \
 	fi
 	@cp $(COV_DIR)/coverage.info $(DOCS_DIR)/coverage/coverage.info
 	genhtml $(COV_DIR)/coverage.info --output-directory $(DOCS_DIR)/coverage/html --ignore-errors inconsistent

--- a/implementations/cpp/Makefile
+++ b/implementations/cpp/Makefile
@@ -47,7 +47,7 @@ coverage:
 	@cmake --build $(BUILD_DIR) -- -j1
 	@cd $(BUILD_DIR) && ctest --output-on-failure
 	@lcov --capture --directory $(BUILD_DIR) --output-file $(BUILD_DIR)/coverage.info --ignore-errors source,gcov
-	@lcov --remove $(BUILD_DIR)/coverage.info '/usr/*' '*/Catch2/*' '*/_deps/*' '*/tests/*' --output-file $(BUILD_DIR)/coverage.info --ignore-errors unused
+	@lcov --remove $(BUILD_DIR)/coverage.info '/usr/*' '*/Catch2/*' '*/_deps/*' '*/tests/*' '*/src/cli.cpp' '*/bench/*' --output-file $(BUILD_DIR)/coverage.info --ignore-errors unused
 	@echo ""
 	@echo "Coverage Summary:"
 	@echo "================="

--- a/implementations/go/Makefile
+++ b/implementations/go/Makefile
@@ -27,12 +27,12 @@ test-report:
 
 coverage:
 	mkdir -p $(BUILD_DIR)
-	go test -coverprofile=$(BUILD_DIR)/coverage.out ./...
+	go test -coverprofile=$(BUILD_DIR)/coverage.out ./pocketplus/...
 	go tool cover -func=$(BUILD_DIR)/coverage.out
 
 coverage-html:
 	mkdir -p $(DOCS_DIR)/coverage
-	go test -coverprofile=$(BUILD_DIR)/coverage.out ./...
+	go test -coverprofile=$(BUILD_DIR)/coverage.out ./pocketplus/...
 	go tool cover -html=$(BUILD_DIR)/coverage.out -o $(DOCS_DIR)/coverage/index.html
 
 docs: coverage-html test-report api-docs

--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -101,6 +101,14 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude CLI from coverage (tested via integration tests) -->
+                        <exclude>**/cli/**</exclude>
+                        <!-- Exclude benchmarks -->
+                        <exclude>**/Benchmark.class</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/implementations/python/pyproject.toml
+++ b/implementations/python/pyproject.toml
@@ -62,3 +62,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+
+[tool.coverage.run]
+omit = [
+    "pocketplus/__main__.py",
+    "pocketplus/cli.py",
+]

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -25,3 +25,7 @@ path = "src/bin/bench.rs"
 opt-level = 3
 lto = true
 codegen-units = 1
+
+# Exclude CLI and benchmarks from coverage
+[package.metadata.tarpaulin]
+exclude-files = ["src/bin/*"]


### PR DESCRIPTION
- C: exclude src/cli.c from lcov coverage
- C++: exclude src/cli.cpp and bench/* from lcov coverage
- Python: add coverage.run.omit for __main__.py and cli.py
- Go: limit coverage to ./pocketplus/... (excludes cmd/)
- Rust: add tarpaulin exclude-files for src/bin/*
- Java: add JaCoCo excludes for cli/** and Benchmark.class

Coverage now reflects core library quality only. CLI is tested via integration tests, benchmarks are performance tools not functional code.

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)