### PR TITLE
docs: add cross-implementation benchmark (#26)

### DIFF
--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -1,0 +1,69 @@
+# Multi-language benchmark container for POCKET+ implementations
+# Builds and benchmarks C, C++, Go, Rust, and Java implementations
+
+FROM alpine:3.20
+
+# Install all build tools for all languages
+RUN apk add --no-cache \
+    # C/C++ tools
+    build-base \
+    cmake \
+    # Go
+    go \
+    # Rust
+    rust \
+    cargo \
+    # Java
+    openjdk21 \
+    maven \
+    # Common tools
+    bash \
+    bc \
+    make \
+    git
+
+# Set JAVA_HOME
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Set working directory
+WORKDIR /app
+
+# Copy all implementations
+COPY implementations/c /app/implementations/c
+COPY implementations/cpp /app/implementations/cpp
+COPY implementations/go /app/implementations/go
+COPY implementations/rust /app/implementations/rust
+COPY implementations/java /app/implementations/java
+
+# Copy test vectors
+COPY test-vectors /app/test-vectors
+
+# Copy benchmark script
+COPY scripts/benchmark.sh /app/scripts/benchmark.sh
+RUN chmod +x /app/scripts/benchmark.sh
+
+# Set test vectors path for implementations that need it
+ENV TEST_VECTORS_DIR=/app/test-vectors
+
+# Build all implementations
+WORKDIR /app/implementations/c
+RUN make clean 2>/dev/null || true && make && make build/test_bench
+
+WORKDIR /app/implementations/cpp
+RUN rm -rf build && make build && (make bench-build 2>/dev/null || true)
+
+WORKDIR /app/implementations/go
+RUN go build ./...
+
+WORKDIR /app/implementations/rust
+RUN cargo build --release && (cargo build --release --bin bench 2>/dev/null || true)
+
+WORKDIR /app/implementations/java
+RUN mvn -q compile
+
+# Back to app root
+WORKDIR /app
+
+# Run benchmark script
+CMD ["/app/scripts/benchmark.sh"]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,40 @@ mvn test               # Run tests
 mvn javadoc:javadoc    # Generate documentation
 ```
 
+## Performance
+
+**Key findings** (venus-express dataset, 151K packets, 13.6 MB):
+- **C++** is the fastest implementation (~140 MB/s compression, ~146 MB/s decompression), also suitable for embedded systems
+- **Java** offers strong performance (~86 MB/s) with JVM convenience
+- **Rust** provides good performance (~65 MB/s)
+- **C** delivers reliable embedded-friendly performance (~58 MB/s)
+- **Go** trades some speed (~49 MB/s) for simplicity and fast compilation
+
+All implementations produce identical compression output. Choose based on your deployment constraints and language ecosystem.
+
+See [Benchmark Results](docs/BENCHMARK.md) for detailed comparison.
+
+### Test Vectors
+
+All vectors are synthetic test data except for venus-express, which contains real housekeeping telemetry from ESA's [Venus Express](https://www.esa.int/Science_Exploration/Space_Science/Venus_Express) mission.
+
+| Vector | Packets | Size | R | pt | ft | rt |
+|--------|---------|------|---|----|----|-----|
+| simple | 100 | 9 KB | 1 | 10 | 20 | 50 |
+| hiro | 100 | 9 KB | 7 | 10 | 20 | 50 |
+| housekeeping | 10,000 | 900 KB | 2 | 20 | 50 | 100 |
+| venus-express | 151,200 | 13.6 MB | 2 | 20 | 50 | 100 |
+
+### Run Benchmarks
+
+```bash
+docker-compose run --rm benchmark
+```
+
+Results are written to `docs/BENCHMARK.md`.
+
+**Note**: Python is excluded from benchmarks as it prioritizes readability over performance.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for versioning strategy, release process, and contribution guidelines.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,18 @@ services:
           create_host_path: true
       - ./test-vectors:/app/test-vectors:ro
 
+  benchmark:
+    build:
+      context: .
+      dockerfile: Dockerfile.benchmark
+    volumes:
+      - type: bind
+        source: ./docs
+        target: /app/docs
+        bind:
+          create_host_path: true
+      - ./test-vectors:/app/test-vectors:ro
+
   java:
     build:
       context: .

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -1,0 +1,124 @@
+# POCKET+ Benchmark Results
+
+Performance comparison across POCKET+ implementations.
+
+## Environment
+
+| Property | Value |
+|----------|-------|
+| OS | Alpine Linux v3.20 |
+| Architecture | aarch64 |
+| CPU | ARMv8 |
+| CPU Cores | 2 |
+| Memory | 1.9 GB |
+| Container | Docker (Alpine 3.20) |
+| Date | 2025-12-12 03:27:38 UTC |
+
+## Test Vectors
+
+All vectors are synthetic test data except for venus-express, which contains real housekeeping telemetry from ESA's [Venus Express](https://www.esa.int/Science_Exploration/Space_Science/Venus_Express) mission.
+
+| Vector | Packets | Size | R | pt | ft | rt |
+|--------|---------|------|---|----|----|-----|
+| simple | 100 | 9.0 KB | 1 | 10 | 20 | 50 |
+| hiro | 100 | 9.0 KB | 7 | 10 | 20 | 50 |
+| housekeeping | 10000 | 900.0 KB | 2 | 20 | 50 | 100 |
+| venus-express | 151200 | 13.6 MB | 2 | 20 | 50 | 100 |
+
+## Compression Results
+
+### Compression: simple (100 packets, 9.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |      .088 |     1128413 |    .88 |             96.85 |
+| C++            |      .025 |     3921568 |    .25 |            336.59 |
+| Go             |      .102 |      979048 |   1.02 |             84.03 |
+| Rust           |      .061 |     1631853 |    .61 |            140.06 |
+| Java           |      .217 |      459791 |   2.17 |             39.46 |
+
+### Compression: hiro (100 packets, 9.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |      .096 |     1036484 |    .96 |             88.96 |
+| C++            |      .031 |     3152585 |    .31 |            270.58 |
+| Go             |      .216 |      462299 |   2.16 |             39.67 |
+| Rust           |      .093 |     1070778 |    .93 |             91.90 |
+| Java           |      .143 |      695265 |   1.43 |             59.67 |
+
+### Compression: housekeeping (10000 packets, 900.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |    11.379 |      878738 |   1.13 |             75.42 |
+| C++            |     4.692 |     2131200 |    .46 |            182.92 |
+| Go             |    14.928 |      669861 |   1.49 |             57.49 |
+| Rust           |     9.536 |     1048569 |    .95 |             89.99 |
+| Java           |     7.865 |     1271404 |    .78 |            109.12 |
+
+### Compression: venus-express (151200 packets, 13608.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |   222.156 |      680599 |   1.46 |             58.41 |
+| C++            |    92.506 |     1634478 |    .61 |            140.28 |
+| Go             |   266.338 |      567698 |   1.76 |             48.72 |
+| Rust           |   198.289 |      762519 |   1.31 |             65.44 |
+| Java           |   149.881 |     1008795 |    .99 |             86.58 |
+
+## Decompression Results
+
+### Decompression: simple (100 packets, 9.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |      .064 |     1539882 |    .64 |            132.16 |
+| C++            |      .023 |     4306632 |    .23 |            369.64 |
+| Go             |      .100 |      998302 |   1.00 |             85.68 |
+| Rust           |      .101 |      982994 |   1.01 |             84.37 |
+| Java           |      .328 |      304247 |   3.28 |             26.11 |
+
+### Decompression: hiro (100 packets, 9.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |      .130 |      767106 |   1.30 |             65.84 |
+| C++            |      .040 |     2455192 |    .40 |            210.73 |
+| Go             |      .200 |      498181 |   2.00 |             42.75 |
+| Rust           |      .137 |      727166 |   1.37 |             62.41 |
+| Java           |      .651 |      153385 |   6.51 |             13.16 |
+
+### Decompression: housekeeping (10000 packets, 900.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |    13.764 |      726504 |   1.37 |             62.35 |
+| C++            |     3.585 |     2788661 |    .35 |            239.35 |
+| Go             |    16.908 |      591406 |   1.69 |             50.76 |
+| Rust           |    13.701 |      729830 |   1.37 |             62.64 |
+| Java           |    15.495 |      645363 |   1.54 |             55.39 |
+
+### Decompression: venus-express (151200 packets, 13608.0 KB)
+
+| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |
+|----------------|-----------|-------------|--------|-------------------|
+| C              |   241.568 |      625909 |   1.59 |             53.72 |
+| C++            |    88.603 |     1706472 |    .58 |            146.46 |
+| Go             |   395.231 |      382561 |   2.61 |             32.83 |
+| Rust           |   305.679 |      494636 |   2.02 |             42.45 |
+| Java           |   317.050 |      476895 |   2.09 |             40.93 |
+
+## Methodology
+
+- **Iterations**: 100 (with 1 warmup iteration)
+- **Packet size**: 90 bytes (720 bits)
+- **Timing**: Wall-clock time for complete file processing
+
+## Notes
+
+- **Python** is excluded from benchmarks as it is not performance-focused.
+  The Python implementation prioritizes readability and correctness over speed.
+- Results may vary based on system load and hardware.
+- Go benchmarks use the native `go test -bench` framework.
+- All other implementations use custom benchmark binaries with consistent output format.

--- a/implementations/c/tests/test_bench.c
+++ b/implementations/c/tests/test_bench.c
@@ -11,6 +11,9 @@
  *   ./build/test_bench 1000 # Run with custom iteration count
  */
 
+/* Enable POSIX features for clock_gettime */
+#define _POSIX_C_SOURCE 199309L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,489 @@
+#!/bin/bash
+# Cross-implementation benchmark script for POCKET+ implementations
+# Runs benchmarks for C, C++, Go, Rust, and Java implementations
+# Generates docs/BENCHMARK.md with comparison tables
+
+set -e
+
+# Configuration
+ITERATIONS=100
+WARMUP=1
+OUTPUT_FILE="/app/docs/BENCHMARK.md"
+
+# Test vector info (packets, size in bytes, R, pt, ft, rt)
+declare -A VECTORS
+VECTORS[simple]="100 9000 1 10 20 50"
+VECTORS[hiro]="100 9000 7 10 20 50"
+VECTORS[housekeeping]="10000 900000 2 20 50 100"
+VECTORS[venus-express]="151200 13608000 2 20 50 100"
+
+# Results storage (associative arrays)
+declare -A COMPRESS_RESULTS
+declare -A DECOMPRESS_RESULTS
+
+# Format a number with commas
+format_number() {
+    if [ "$1" = "-" ] || [ -z "$1" ]; then
+        echo "-"
+    else
+        printf "%'d" "$1" 2>/dev/null || printf "%d" "$1"
+    fi
+}
+
+# Calculate packets per second from time (µs) and packet count
+# Input: time_us (microseconds, may be decimal), packets
+calc_packets_per_sec() {
+    local time_us=$1
+    local packets=$2
+    # Use bc for comparison since time_us may be decimal
+    if [ "$(echo "$time_us > 0" | bc)" -eq 1 ]; then
+        echo "scale=0; ($packets * 1000000) / $time_us" | bc
+    else
+        echo "-"
+    fi
+}
+
+# Calculate throughput in MB/s from size (bytes) and time (µs)
+# Input: size_bytes, time_us (microseconds, may be decimal)
+# Formula: (bytes / 1048576) / (us / 1000000) = (bytes * 1000000) / (us * 1048576)
+calc_throughput_mbs() {
+    local size_bytes=$1
+    local time_us=$2
+    # Use bc for comparison since time_us may be decimal
+    if [ "$(echo "$time_us > 0" | bc)" -eq 1 ]; then
+        echo "scale=2; ($size_bytes * 1000000) / ($time_us * 1048576)" | bc
+    else
+        echo "-"
+    fi
+}
+
+# Run C benchmarks
+run_c_bench() {
+    echo "Running C benchmarks..."
+    cd /app/implementations/c
+
+    if [ -f "build/test_bench" ]; then
+        local output
+        output=$(./build/test_bench 2>&1) || true
+
+        # Parse output: "test-name    XX.XX µs/iter  X.XX µs/pkt  XXXX.X Kbps  (NNN pkts)"
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^([a-z-]+)[[:space:]]+([0-9.]+)[[:space:]]+µs/iter ]]; then
+                local test_name="${BASH_REMATCH[1]}"
+                local us_per_iter="${BASH_REMATCH[2]}"
+
+                # Determine if compress or decompress based on output order
+                # C bench runs compress then decompress for each vector
+                local vector_info="${VECTORS[$test_name]}"
+                if [ -n "$vector_info" ]; then
+                    read -r packets size_bytes r pt ft rt <<< "$vector_info"
+                    local time_ms us_per_pkt pps throughput
+                    time_ms=$(echo "scale=3; $us_per_iter / 1000" | bc)
+                    us_per_pkt=$(echo "scale=2; $us_per_iter / $packets" | bc)
+                    pps=$(calc_packets_per_sec "$us_per_iter" "$packets")
+                    throughput=$(calc_throughput_mbs "$size_bytes" "$us_per_iter")
+
+                    # Store result: time_ms|us_per_pkt|packets_per_sec|throughput_mbs
+                    if [ -z "${COMPRESS_RESULTS[c_$test_name]}" ]; then
+                        COMPRESS_RESULTS["c_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    else
+                        DECOMPRESS_RESULTS["c_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    fi
+                fi
+            fi
+        done <<< "$output"
+    else
+        echo "  Warning: C benchmark binary not found"
+    fi
+}
+
+# Run C++ benchmarks
+run_cpp_bench() {
+    echo "Running C++ benchmarks..."
+    cd /app/implementations/cpp
+
+    if [ -f "build/bench" ]; then
+        local output
+        output=$(./build/bench 2>&1) || true
+
+        # Parse output - same format as C
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^([a-z-]+)[[:space:]]+([0-9.]+)[[:space:]]+µs/iter ]]; then
+                local test_name="${BASH_REMATCH[1]}"
+                local us_per_iter="${BASH_REMATCH[2]}"
+
+                local vector_info="${VECTORS[$test_name]}"
+                if [ -n "$vector_info" ]; then
+                    read -r packets size_bytes r pt ft rt <<< "$vector_info"
+                    local time_ms us_per_pkt pps throughput
+                    time_ms=$(echo "scale=3; $us_per_iter / 1000" | bc)
+                    us_per_pkt=$(echo "scale=2; $us_per_iter / $packets" | bc)
+                    pps=$(calc_packets_per_sec "$us_per_iter" "$packets")
+                    throughput=$(calc_throughput_mbs "$size_bytes" "$us_per_iter")
+
+                    if [ -z "${COMPRESS_RESULTS[cpp_$test_name]}" ]; then
+                        COMPRESS_RESULTS["cpp_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    else
+                        DECOMPRESS_RESULTS["cpp_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    fi
+                fi
+            fi
+        done <<< "$output"
+    else
+        echo "  Warning: C++ benchmark binary not found"
+    fi
+}
+
+# Run Go benchmarks
+run_go_bench() {
+    echo "Running Go benchmarks..."
+    cd /app/implementations/go
+
+    local output
+    output=$(go test -bench=. -benchtime=100x ./pocketplus 2>&1) || true
+
+    # Parse Go output: "BenchmarkCompressSimple-N    100    XXXX ns/op    XX.XX MB/s"
+    while IFS= read -r line; do
+        if [[ "$line" =~ Benchmark(Compress|Decompress)([A-Za-z]+)-[0-9]+[[:space:]]+[0-9]+[[:space:]]+([0-9]+)[[:space:]]ns/op ]]; then
+            local op_type="${BASH_REMATCH[1]}"
+            local vector_name="${BASH_REMATCH[2]}"
+            local ns_per_op="${BASH_REMATCH[3]}"
+
+            # Convert vector name to lowercase with hyphens
+            local test_name
+            test_name=$(echo "$vector_name" | sed 's/\([A-Z]\)/-\1/g' | sed 's/^-//' | tr '[:upper:]' '[:lower:]')
+            # Handle special cases
+            test_name="${test_name/venus-express/venus-express}"
+
+            local vector_info="${VECTORS[$test_name]}"
+            if [ -n "$vector_info" ]; then
+                read -r packets size_bytes r pt ft rt <<< "$vector_info"
+                # Convert ns to µs for calculations
+                local us_per_iter time_ms us_per_pkt pps throughput
+                us_per_iter=$(echo "scale=2; $ns_per_op / 1000" | bc)
+                time_ms=$(echo "scale=3; $ns_per_op / 1000000" | bc)
+                us_per_pkt=$(echo "scale=2; $us_per_iter / $packets" | bc)
+                pps=$(calc_packets_per_sec "$us_per_iter" "$packets")
+                throughput=$(calc_throughput_mbs "$size_bytes" "$us_per_iter")
+
+                if [ "$op_type" = "Compress" ]; then
+                    COMPRESS_RESULTS["go_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                else
+                    DECOMPRESS_RESULTS["go_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                fi
+            fi
+        fi
+    done <<< "$output"
+}
+
+# Run Rust benchmarks
+run_rust_bench() {
+    echo "Running Rust benchmarks..."
+    cd /app/implementations/rust
+
+    if [ -f "target/release/bench" ]; then
+        local output
+        output=$(./target/release/bench 2>&1) || true
+
+        # Parse output - same format as C/C++
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^([a-z-]+)[[:space:]]+([0-9.]+)[[:space:]]+µs/iter ]]; then
+                local test_name="${BASH_REMATCH[1]}"
+                local us_per_iter="${BASH_REMATCH[2]}"
+
+                local vector_info="${VECTORS[$test_name]}"
+                if [ -n "$vector_info" ]; then
+                    read -r packets size_bytes r pt ft rt <<< "$vector_info"
+                    local time_ms us_per_pkt pps throughput
+                    time_ms=$(echo "scale=3; $us_per_iter / 1000" | bc)
+                    us_per_pkt=$(echo "scale=2; $us_per_iter / $packets" | bc)
+                    pps=$(calc_packets_per_sec "$us_per_iter" "$packets")
+                    throughput=$(calc_throughput_mbs "$size_bytes" "$us_per_iter")
+
+                    if [ -z "${COMPRESS_RESULTS[rust_$test_name]}" ]; then
+                        COMPRESS_RESULTS["rust_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    else
+                        DECOMPRESS_RESULTS["rust_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                    fi
+                fi
+            fi
+        done <<< "$output"
+    else
+        echo "  Warning: Rust benchmark binary not found"
+    fi
+}
+
+# Run Java benchmarks
+run_java_bench() {
+    echo "Running Java benchmarks..."
+    cd /app/implementations/java
+
+    local output
+    output=$(java -cp target/classes space.tanagra.pocketplus.cli.Bench 2>&1) || true
+
+    # Parse output - same format as C/C++
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^([a-z-]+)[[:space:]]+([0-9.]+)[[:space:]]+µs/iter ]]; then
+            local test_name="${BASH_REMATCH[1]}"
+            local us_per_iter="${BASH_REMATCH[2]}"
+
+            local vector_info="${VECTORS[$test_name]}"
+            if [ -n "$vector_info" ]; then
+                read -r packets size_bytes r pt ft rt <<< "$vector_info"
+                local time_ms us_per_pkt pps throughput
+                time_ms=$(echo "scale=3; $us_per_iter / 1000" | bc)
+                us_per_pkt=$(echo "scale=2; $us_per_iter / $packets" | bc)
+                pps=$(calc_packets_per_sec "$us_per_iter" "$packets")
+                throughput=$(calc_throughput_mbs "$size_bytes" "$us_per_iter")
+
+                if [ -z "${COMPRESS_RESULTS[java_$test_name]}" ]; then
+                    COMPRESS_RESULTS["java_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                else
+                    DECOMPRESS_RESULTS["java_$test_name"]="$time_ms|$us_per_pkt|$pps|$throughput"
+                fi
+            fi
+        fi
+    done <<< "$output"
+}
+
+# Get result value or placeholder
+get_result() {
+    local key=$1
+    local field=$2
+    local result="${!key}"
+
+    if [ -n "$result" ]; then
+        echo "$result" | cut -d'|' -f"$field"
+    else
+        echo "-"
+    fi
+}
+
+# Generate comparison table for a test vector
+generate_vector_table() {
+    local vector=$1
+    local op_type=$2  # "compress" or "decompress"
+    local results_array=$3
+
+    local vector_info="${VECTORS[$vector]}"
+    read -r packets size_bytes r pt ft rt <<< "$vector_info"
+    local size_kb
+    size_kb=$(echo "scale=1; $size_bytes / 1000" | bc -l)
+
+    if [ "$op_type" = "compress" ]; then
+        echo "### Compression: $vector ($packets packets, ${size_kb} KB)"
+    else
+        echo "### Decompression: $vector ($packets packets, ${size_kb} KB)"
+    fi
+    echo ""
+    echo "| Implementation | Time (ms) | Packets/sec | µs/pkt | Throughput (MB/s) |"
+    echo "|----------------|-----------|-------------|--------|-------------------|"
+
+    for lang in c cpp go rust java; do
+        local key
+        if [ "$op_type" = "compress" ]; then
+            key="COMPRESS_RESULTS[${lang}_${vector}]"
+        else
+            key="DECOMPRESS_RESULTS[${lang}_${vector}]"
+        fi
+
+        local result="${!key}"
+        local lang_name
+        case $lang in
+            c) lang_name="C" ;;
+            cpp) lang_name="C++" ;;
+            go) lang_name="Go" ;;
+            rust) lang_name="Rust" ;;
+            java) lang_name="Java" ;;
+        esac
+
+        if [ -n "$result" ]; then
+            local time_ms us_pkt pps throughput
+            time_ms=$(echo "$result" | cut -d'|' -f1)
+            us_pkt=$(echo "$result" | cut -d'|' -f2)
+            pps=$(echo "$result" | cut -d'|' -f3)
+            throughput=$(echo "$result" | cut -d'|' -f4)
+
+            # Format packets/sec with commas
+            pps_formatted=$(format_number "$pps")
+
+            printf "| %-14s | %9s | %11s | %6s | %17s |\n" \
+                "$lang_name" "$time_ms" "$pps_formatted" "$us_pkt" "$throughput"
+        else
+            printf "| %-14s | %9s | %11s | %6s | %17s |\n" \
+                "$lang_name" "-" "-" "-" "-"
+        fi
+    done
+    echo ""
+}
+
+# Gather system information
+get_system_info() {
+    local os_info cpu_info mem_info arch_info cpu_cores
+
+    # OS information
+    if [ -f /etc/os-release ]; then
+        os_info=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
+    else
+        os_info=$(uname -s -r)
+    fi
+
+    # Architecture
+    arch_info=$(uname -m)
+
+    # CPU information
+    if [ -f /proc/cpuinfo ]; then
+        # Try x86 format first (model name)
+        cpu_info=$(grep "model name" /proc/cpuinfo | head -1 | cut -d':' -f2 | sed 's/^ //')
+        # If empty, try ARM format (CPU architecture + features summary)
+        if [ -z "$cpu_info" ]; then
+            local cpu_arch cpu_impl
+            cpu_arch=$(grep "CPU architecture" /proc/cpuinfo | head -1 | cut -d':' -f2 | sed 's/^ //')
+            cpu_impl=$(grep "CPU implementer" /proc/cpuinfo | head -1 | cut -d':' -f2 | sed 's/^ //')
+            if [ -n "$cpu_arch" ]; then
+                cpu_info="ARMv${cpu_arch}"
+            fi
+        fi
+    fi
+    if [ -z "$cpu_info" ]; then
+        cpu_info=$(uname -m)
+    fi
+
+    # CPU cores
+    cpu_cores=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "unknown")
+
+    # Memory information
+    if [ -f /proc/meminfo ]; then
+        local mem_kb
+        mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+        mem_info=$(echo "scale=1; $mem_kb / 1048576" | bc)" GB"
+    else
+        mem_info="unknown"
+    fi
+
+    printf 'OS_INFO=%q\n' "$os_info"
+    printf 'ARCH_INFO=%q\n' "$arch_info"
+    printf 'CPU_INFO=%q\n' "$cpu_info"
+    printf 'CPU_CORES=%q\n' "$cpu_cores"
+    printf 'MEM_INFO=%q\n' "$mem_info"
+}
+
+# Generate the markdown report
+generate_markdown() {
+    echo "Generating benchmark report..."
+
+    mkdir -p /app/docs
+
+    # Gather system info
+    eval "$(get_system_info)"
+
+    cat > "$OUTPUT_FILE" << EOF
+# POCKET+ Benchmark Results
+
+Performance comparison across POCKET+ implementations.
+
+## Environment
+
+| Property | Value |
+|----------|-------|
+| OS | $OS_INFO |
+| Architecture | $ARCH_INFO |
+| CPU | $CPU_INFO |
+| CPU Cores | $CPU_CORES |
+| Memory | $MEM_INFO |
+| Container | Docker (Alpine 3.20) |
+| Date | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |
+
+## Test Vectors
+
+All vectors are synthetic test data except for venus-express, which contains real housekeeping telemetry from ESA's [Venus Express](https://www.esa.int/Science_Exploration/Space_Science/Venus_Express) mission.
+
+| Vector | Packets | Size | R | pt | ft | rt |
+|--------|---------|------|---|----|----|-----|
+EOF
+
+    # Add test vector rows
+    for vector in simple hiro housekeeping venus-express; do
+        local vector_info="${VECTORS[$vector]}"
+        read -r packets size_bytes r pt ft rt <<< "$vector_info"
+        local size_display
+        if [ "$size_bytes" -ge 1000000 ]; then
+            size_display=$(echo "scale=1; $size_bytes / 1000000" | bc -l)" MB"
+        else
+            size_display=$(echo "scale=1; $size_bytes / 1000" | bc -l)" KB"
+        fi
+        echo "| $vector | $(format_number "$packets") | $size_display | $r | $pt | $ft | $rt |" >> "$OUTPUT_FILE"
+    done
+
+    cat >> "$OUTPUT_FILE" << 'SECTION'
+
+## Compression Results
+
+SECTION
+
+    # Generate compression tables for each vector
+    for vector in simple hiro housekeeping venus-express; do
+        generate_vector_table "$vector" "compress" >> "$OUTPUT_FILE"
+    done
+
+    cat >> "$OUTPUT_FILE" << 'SECTION'
+## Decompression Results
+
+SECTION
+
+    # Generate decompression tables for each vector
+    for vector in simple hiro housekeeping venus-express; do
+        generate_vector_table "$vector" "decompress" >> "$OUTPUT_FILE"
+    done
+
+    cat >> "$OUTPUT_FILE" << 'FOOTER'
+## Methodology
+
+- **Iterations**: 100 (with 1 warmup iteration)
+- **Packet size**: 90 bytes (720 bits)
+- **Timing**: Wall-clock time for complete file processing
+
+## Notes
+
+- **Python** is excluded from benchmarks as it is not performance-focused.
+  The Python implementation prioritizes readability and correctness over speed.
+- Results may vary based on system load and hardware.
+- Go benchmarks use the native `go test -bench` framework.
+- All other implementations use custom benchmark binaries with consistent output format.
+FOOTER
+
+    echo "Report generated: $OUTPUT_FILE"
+}
+
+# Main execution
+main() {
+    echo "=========================================="
+    echo "POCKET+ Cross-Implementation Benchmarks"
+    echo "=========================================="
+    echo ""
+
+    # Run all benchmarks
+    run_c_bench
+    run_cpp_bench
+    run_go_bench
+    run_rust_bench
+    run_java_bench
+
+    echo ""
+    echo "=========================================="
+    echo "Generating Report"
+    echo "=========================================="
+
+    # Generate markdown report
+    generate_markdown
+
+    echo ""
+    echo "=========================================="
+    echo "Benchmark Complete"
+    echo "=========================================="
+
+    # Display results summary
+    cat "$OUTPUT_FILE"
+}
+
+main "$@"


### PR DESCRIPTION
Add Docker-based benchmark system for comparing POCKET+ implementations:

- Create Dockerfile.benchmark with C, C++, Go, Rust, Java runtimes
- Add scripts/benchmark.sh to run benchmarks and generate markdown report
- Add benchmark service to docker-compose.yml
- Generate docs/BENCHMARK.md with detailed performance comparison
- Update README.md with key performance findings and test vectors
- Fix C test_bench.c POSIX compatibility for Alpine Linux

Benchmarks run manually via `docker-compose run --rm benchmark`. Python excluded as it prioritizes readability over performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)