### PR TITLE
docs: add documentation URL to all CLI help outputs (#24)

### DIFF
--- a/implementations/c/src/cli.c
+++ b/implementations/c/src/cli.c
@@ -62,7 +62,8 @@ static void print_help(const char *prog_name) {
     printf("=================================================\n\n");
     printf("References:\n");
     printf("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf\n");
-    printf("  ESA POCKET+: https://opssat.esa.int/pocket-plus/\n\n");
+    printf("  ESA POCKET+: https://opssat.esa.int/pocket-plus/\n");
+    printf("  Documentation: https://tanagraspace.com/pocket-plus\n\n");
     printf("Citation:\n");
     printf("  D. Evans, G. Labreche, D. Marszk, S. Bammens, M. Hernandez-Cabronero,\n");
     printf("  V. Zelenevskiy, V. Shiradhonkar, M. Starcik, and M. Henkel. 2022.\n");

--- a/implementations/cpp/src/cli.cpp
+++ b/implementations/cpp/src/cli.cpp
@@ -51,7 +51,8 @@ static void print_help(const char* prog_name) {
     std::printf("=================================================\n\n");
     std::printf("References:\n");
     std::printf("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf\n");
-    std::printf("  ESA POCKET+: https://opssat.esa.int/pocket-plus/\n\n");
+    std::printf("  ESA POCKET+: https://opssat.esa.int/pocket-plus/\n");
+    std::printf("  Documentation: https://tanagraspace.com/pocket-plus\n\n");
     std::printf("Usage:\n");
     std::printf("  %s <input> <packet_size> <pt> <ft> <rt> <robustness>\n", prog_name);
     std::printf("  %s -d <input.pkt> <packet_size> <robustness>\n\n", prog_name);

--- a/implementations/go/cmd/pocketplus/main.go
+++ b/implementations/go/cmd/pocketplus/main.go
@@ -34,6 +34,7 @@ func printHelp(progName string) {
 	fmt.Println("References:")
 	fmt.Println("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf")
 	fmt.Println("  ESA POCKET+: https://opssat.esa.int/pocket-plus/")
+	fmt.Println("  Documentation: https://tanagraspace.com/pocket-plus")
 	fmt.Println()
 	fmt.Println("Citation:")
 	fmt.Println("  D. Evans, G. Labreche, D. Marszk, S. Bammens, M. Hernandez-Cabronero,")

--- a/implementations/java/src/main/java/space/tanagra/pocketplus/cli/Main.java
+++ b/implementations/java/src/main/java/space/tanagra/pocketplus/cli/Main.java
@@ -196,6 +196,7 @@ public final class Main {
     System.out.println("References:");
     System.out.println("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf");
     System.out.println("  ESA POCKET+: https://opssat.esa.int/pocket-plus/");
+    System.out.println("  Documentation: https://tanagraspace.com/pocket-plus");
     System.out.println();
     System.out.println("Citation:");
     System.out.println("  D. Evans, G. Labreche, D. Marszk, S. Bammens, M. Hernandez-Cabronero,");

--- a/implementations/python/cli.py
+++ b/implementations/python/cli.py
@@ -47,6 +47,7 @@ def print_help(prog_name: str) -> None:
     print("References:")
     print("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf")
     print("  ESA POCKET+: https://opssat.esa.int/pocket-plus/")
+    print("  Documentation: https://tanagraspace.com/pocket-plus")
     print()
     print("Citation:")
     print("  D. Evans, G. Labreche, D. Marszk, S. Bammens, M. Hernandez-Cabronero,")

--- a/implementations/rust/src/bin/pocketplus.rs
+++ b/implementations/rust/src/bin/pocketplus.rs
@@ -44,7 +44,8 @@ fn print_help(prog_name: &str) {
     println!("=================================================\n");
     println!("References:");
     println!("  CCSDS 124.0-B-1: https://ccsds.org/Pubs/124x0b1.pdf");
-    println!("  ESA POCKET+: https://opssat.esa.int/pocket-plus/\n");
+    println!("  ESA POCKET+: https://opssat.esa.int/pocket-plus/");
+    println!("  Documentation: https://tanagraspace.com/pocket-plus\n");
     println!("Citation:");
     println!("  D. Evans, G. Labreche, D. Marszk, S. Bammens, M. Hernandez-Cabronero,");
     println!("  V. Zelenevskiy, V. Shiradhonkar, M. Starcik, and M. Henkel. 2022.");


### PR DESCRIPTION
Add https://tanagraspace.com/pocket-plus to the References section of CLI help output in all implementations:

- C: implementations/c/src/cli.c
- C++: implementations/cpp/src/cli.cpp
- Go: implementations/go/cmd/pocketplus/main.go
- Java: implementations/java/src/main/java/space/tanagra/pocketplus/cli/Main.java
- Python: implementations/python/cli.py
- Rust: implementations/rust/src/bin/pocketplus.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)