### PR TITLE
fix(rust): exclude src/bin/ from coverage report in pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -338,7 +338,7 @@ jobs:
         working-directory: implementations/rust
         run: |
           mkdir -p build/docs/coverage
-          cargo tarpaulin --out Html --output-dir build/docs/coverage
+          cargo tarpaulin --out Html --output-dir build/docs/coverage --exclude-files "src/bin/*"
           mv build/docs/coverage/tarpaulin-report.html build/docs/coverage/index.html
 
       - name: Generate API docs


### PR DESCRIPTION
## Summary

Add `--exclude-files "src/bin/*"` to tarpaulin command in pages.yml to exclude CLI binaries from coverage report.

## Changes

- Updated `cargo tarpaulin` command in pages.yml to match rust-build.yml and Cargo.toml configuration

## Before

```yaml
cargo tarpaulin --out Html --output-dir build/docs/coverage
```

## After

```yaml
cargo tarpaulin --out Html --output-dir build/docs/coverage --exclude-files "src/bin/*"
```

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)