### PR TITLE
docs: link coverage badges to hosted coverage reports

### DIFF
--- a/implementations/c/README.md
+++ b/implementations/c/README.md
@@ -1,8 +1,8 @@
 # POCKET+ C Implementation
 
 [![Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/c-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/c-build.yml)
-![Lines](assets/coverage-lines.svg)
-![Functions](assets/coverage-functions.svg)
+[![Lines](assets/coverage-lines.svg)](https://tanagraspace.com/pocket-plus/c/coverage/)
+[![Functions](assets/coverage-functions.svg)](https://tanagraspace.com/pocket-plus/c/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A MISRA-C compliant C implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) POCKET+ lossless compression algorithm of fixed-length housekeeping data.

--- a/implementations/cpp/README.md
+++ b/implementations/cpp/README.md
@@ -1,8 +1,8 @@
 # POCKET+ C++ Implementation
 
 [![C++ Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/cpp-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/cpp-build.yml)
-![Lines](assets/coverage-lines.svg)
-![Functions](assets/coverage-functions.svg)
+[![Lines](assets/coverage-lines.svg)](https://tanagraspace.com/pocket-plus/cpp/coverage/)
+[![Functions](assets/coverage-functions.svg)](https://tanagraspace.com/pocket-plus/cpp/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Header-only C++17 implementation of CCSDS 124.0-B-1 POCKET+ lossless compression algorithm.

--- a/implementations/go/README.md
+++ b/implementations/go/README.md
@@ -1,7 +1,7 @@
 # POCKET+ Go Implementation
 
 [![Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/go-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/go-build.yml)
-![Coverage](assets/coverage.svg)
+[![Coverage](assets/coverage.svg)](https://tanagraspace.com/pocket-plus/go/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Go implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) POCKET+ lossless compression algorithm for fixed-length housekeeping data.

--- a/implementations/java/README.md
+++ b/implementations/java/README.md
@@ -1,7 +1,7 @@
 # POCKET+ Java Implementation
 
 [![Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/java-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/java-build.yml)
-![Coverage](assets/coverage.svg)
+[![Coverage](assets/coverage.svg)](https://tanagraspace.com/pocket-plus/java/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Java implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) POCKET+ lossless compression algorithm for satellite housekeeping telemetry.

--- a/implementations/python/README.md
+++ b/implementations/python/README.md
@@ -2,7 +2,7 @@
 
 [![Python Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/python-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/python-build.yml)
 [![MicroPython Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/micropython-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/micropython-build.yml)
-![Coverage](assets/coverage.svg)
+[![Coverage](assets/coverage.svg)](https://tanagraspace.com/pocket-plus/python/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Python and MicroPython compatible implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) POCKET+ lossless compression algorithm of fixed-length housekeeping data.

--- a/implementations/rust/README.md
+++ b/implementations/rust/README.md
@@ -1,7 +1,7 @@
 # POCKET+ Rust Implementation
 
 [![Build](https://github.com/tanagraspace/pocket-plus/actions/workflows/rust-build.yml/badge.svg)](https://github.com/tanagraspace/pocket-plus/actions/workflows/rust-build.yml)
-![Coverage](assets/coverage.svg)
+[![Coverage](assets/coverage.svg)](https://tanagraspace.com/pocket-plus/rust/coverage/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Rust implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) POCKET+ lossless compression algorithm of fixed-length housekeeping data.


### PR DESCRIPTION
## Summary

Link coverage badges in all implementation READMEs to their respective hosted coverage reports.

## Changes

Updated all 6 implementation READMEs to wrap coverage badge images in links:

| Implementation | Coverage Report URL |
|----------------|---------------------|
| C | https://tanagraspace.com/pocket-plus/c/coverage/ |
| C++ | https://tanagraspace.com/pocket-plus/cpp/coverage/ |
| Go | https://tanagraspace.com/pocket-plus/go/coverage/ |
| Python | https://tanagraspace.com/pocket-plus/python/coverage/ |
| Rust | https://tanagraspace.com/pocket-plus/rust/coverage/ |
| Java | https://tanagraspace.com/pocket-plus/java/coverage/ |

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)