### PR TITLE
fix(rust): exclude tests/ from coverage to fix badge discrepancy

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           mkdir -p build/coverage
-          cargo tarpaulin --out Html --output-dir build/coverage 2>&1 | tee coverage-output.txt
+          cargo tarpaulin --out Html --output-dir build/coverage --exclude-files "src/bin/*" --exclude-files "tests/*" 2>&1 | tee coverage-output.txt
 
       - name: Parse coverage summary
         run: |

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -26,6 +26,6 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
-# Exclude CLI and benchmarks from coverage
+# Exclude CLI, benchmarks, and tests from coverage
 [package.metadata.tarpaulin]
-exclude-files = ["src/bin/*"]
+exclude-files = ["src/bin/*", "tests/*"]

--- a/implementations/rust/Makefile
+++ b/implementations/rust/Makefile
@@ -30,7 +30,7 @@ bench:
 
 coverage:
 	mkdir -p $(BUILD_DIR)/coverage
-	cargo tarpaulin --out Html --output-dir $(BUILD_DIR)/coverage
+	cargo tarpaulin --out Html --output-dir $(BUILD_DIR)/coverage --exclude-files "src/bin/*" --exclude-files "tests/*"
 	@mv $(BUILD_DIR)/coverage/tarpaulin-report.html $(BUILD_DIR)/coverage/index.html 2>/dev/null || true
 
 fmt:


### PR DESCRIPTION
## Summary

- Exclude `tests/*` directory from tarpaulin coverage calculation in addition to `src/bin/*`
- Coverage badge showed 69% while hosted report showed 94% because test helper code was inflating the coverage calculation
- Updates made in `rust-build.yml`, `Cargo.toml`, and `Makefile` for consistency

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)