### PR TITLE
fix(java): fix broken Built by Maven image in Surefire test report

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -389,6 +389,7 @@ jobs:
           mvn test surefire-report:report-only site -DgenerateReports=false
           cp target/site/surefire-report.html build/docs/tests/index.html
           cp -r target/site/css build/docs/tests/ 2>/dev/null || true
+          cp -r target/site/images build/docs/tests/ 2>/dev/null || true
 
       - name: Generate coverage HTML
         working-directory: implementations/java


### PR DESCRIPTION
## Summary

- Copy the `images` directory when deploying Java Surefire test report to GitHub Pages
- The report references `./images/logos/maven-feather.png` which was missing because only `css` was being copied

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)