### PR TITLE
docs: simplify ESA POCKET+ link text in landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
     <ul>
       <li><a href="https://github.com/tanagraspace/pocket-plus">GitHub Repository</a></li>
       <li><a href="https://ccsds.org/Pubs/124x0b1.pdf">CCSDS 124.0-B-1 Specification</a></li>
-      <li><a href="https://opssat.esa.int/pocket-plus/">ESA POCKET+ Reference Implementation</a></li>
+      <li><a href="https://opssat.esa.int/pocket-plus/">ESA POCKET+</a></li>
     </ul>
   </div>
 </body>


### PR DESCRIPTION
## Summary

- Simplify link text from "ESA POCKET+ Reference Implementation" to "ESA POCKET+"

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)