### PR TITLE
fix(ci): copy test report html/* to correct path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Prepare C artifacts
         run: |
-          mkdir -p _site/c
+          mkdir -p _site/c/tests
           cp -r implementations/c/build/docs/api/html _site/c/api
           cp -r implementations/c/build/docs/coverage/html _site/c/coverage
-          cp -r implementations/c/build/docs/tests _site/c/tests
+          cp -r implementations/c/build/docs/tests/html/* _site/c/tests/
 
       - name: Upload C docs artifact
         uses: actions/upload-artifact@v4
@@ -89,7 +89,7 @@ jobs:
           mkdir -p _site/cpp/api _site/cpp/coverage _site/cpp/tests
           cp -r implementations/cpp/build/docs/api/html/* _site/cpp/api/ 2>/dev/null || echo "No API docs"
           cp -r implementations/cpp/build/docs/coverage/html/* _site/cpp/coverage/ 2>/dev/null || echo "No coverage report"
-          cp -r implementations/cpp/build/docs/tests/* _site/cpp/tests/ 2>/dev/null || echo "No test report"
+          cp -r implementations/cpp/build/docs/tests/html/* _site/cpp/tests/ 2>/dev/null || echo "No test report"
 
       - name: Upload C++ docs artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fix 404 errors on C and C++ test report pages by updating the artifact copy commands in pages.yml.

## Problem

After PR #73 moved test reports to `build/docs/tests/html/index.html`, the pages.yml was copying the entire `tests/` directory, resulting in the HTML being at `_site/c/tests/html/index.html` instead of `_site/c/tests/index.html`.

## Solution

Update copy commands to copy `tests/html/*` instead of `tests/*`:
- C: `cp -r implementations/c/build/docs/tests/html/* _site/c/tests/`
- C++: `cp -r implementations/cpp/build/docs/tests/html/* _site/cpp/tests/`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)