### PR TITLE
chore: add Google Analytics to landing page (#40)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-D3Z8PVELJD"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-D3Z8PVELJD');
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tanagra Space</title>


### PR DESCRIPTION
## Summary

Add Google Tag (gtag.js) tracking to the landing page

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)