### PR TITLE
c: optimize hot paths in compression and decompression (#82)

### DIFF
--- a/implementations/c/include/pocketplus.h
+++ b/implementations/c/include/pocketplus.h
@@ -138,20 +138,41 @@ void bitvector_zero(bitvector_t *bv);
 void bitvector_copy(bitvector_t *dest, const bitvector_t *src);
 
 /**
- * @brief Get bit value at position.
+ * @brief Get bit value at position (inline for performance).
  * @param[in] bv  Bit vector
  * @param[in] pos Bit position (0 = LSB, length-1 = MSB)
  * @return Bit value (0 or 1)
  */
-int bitvector_get_bit(const bitvector_t *bv, size_t pos);
+static inline int bitvector_get_bit(const bitvector_t *bv, size_t pos) {
+    int result = 0;
+    if ((bv != NULL) && (pos < bv->length)) {
+        size_t word_index = pos >> 5U;
+        size_t bit_in_word = 31U - (pos & 31U);
+        uint32_t shifted = bv->data[word_index] >> bit_in_word;
+        if ((shifted & 1U) != 0U) {
+            result = 1;
+        }
+    }
+    return result;
+}
 
 /**
- * @brief Set bit value at position.
+ * @brief Set bit value at position (inline for performance).
  * @param[out] bv    Bit vector to modify
  * @param[in]  pos   Bit position (0 = LSB, length-1 = MSB)
  * @param[in]  value Bit value (0 or 1)
  */
-void bitvector_set_bit(bitvector_t *bv, size_t pos, int value);
+static inline void bitvector_set_bit(bitvector_t *bv, size_t pos, int value) {
+    if ((bv != NULL) && (pos < bv->length)) {
+        size_t word_index = pos >> 5U;
+        size_t bit_in_word = 31U - (pos & 31U);
+        if (value != 0) {
+            bv->data[word_index] |= (1U << bit_in_word);
+        } else {
+            bv->data[word_index] &= ~(1U << bit_in_word);
+        }
+    }
+}
 
 /**
  * @brief Bitwise XOR operation.

--- a/implementations/c/src/bitvector.c
+++ b/implementations/c/src/bitvector.c
@@ -79,56 +79,7 @@ void bitvector_copy(bitvector_t *dest, const bitvector_t *src) {
 
 /** @} */ /* End of Initialization Functions */
 
-/**
- * @name Bit Access Functions
- *
- * Big-endian word packing maps bytes to word bits as follows:
- * - Word[i] contains Bytes [4i, 4i+1, 4i+2, 4i+3]
- * - Byte 4i at bits 24-31 (most significant)
- * - Byte 4i+1 at bits 16-23
- * - Byte 4i+2 at bits 8-15
- * - Byte 4i+3 at bits 0-7 (least significant)
- * @{
- */
-
-
-int bitvector_get_bit(const bitvector_t *bv, size_t pos) {
-    int result = 0;
-
-    if ((bv != NULL) && (pos < bv->length)) {
-        /* Direct bit-to-word mapping (optimized):
-         * word_index = pos / 32, bit_in_word = 31 - (pos % 32)
-         * MSB-first: bit 0 is at position 31 in word 0 */
-        size_t word_index = pos >> 5U;
-        size_t bit_in_word = 31U - (pos & 31U);
-
-        uint32_t shifted = bv->data[word_index] >> bit_in_word;
-        if ((shifted & 1U) != 0U) {
-            result = 1;
-        }
-    }
-
-    return result;
-}
-
-
-void bitvector_set_bit(bitvector_t *bv, size_t pos, int value) {
-    if ((bv != NULL) && (pos < bv->length)) {
-        /* Direct bit-to-word mapping (optimized):
-         * word_index = pos / 32, bit_in_word = 31 - (pos % 32)
-         * MSB-first: bit 0 is at position 31 in word 0 */
-        size_t word_index = pos >> 5U;
-        size_t bit_in_word = 31U - (pos & 31U);
-
-        if (value != 0) {
-            bv->data[word_index] |= (1U << bit_in_word);
-        } else {
-            bv->data[word_index] &= ~(1U << bit_in_word);
-        }
-    }
-}
-
-/** @} */ /* End of Bit Access Functions */
+/* Note: bitvector_get_bit and bitvector_set_bit are now static inline in pocketplus.h */
 
 /**
  * @name Bitwise Operations


### PR DESCRIPTION
Major decompression performance improvements:

1. Add bitvector_get_set_positions() helper function that extracts positions of set bits using word-level processing with __builtin_clz, instead of iterating bit-by-bit through the entire vector.

2. Optimize hot paths in pocket_decompress_packet():
   - Pre-extract change positions once, reuse for kt reading and mask updates
   - Replace O(F) bit-by-bit loops with O(hamming_weight) position-based loops
   - Optimize pocket_bit_insert() to use word-level position extraction

3. Inline bitvector_get_bit() and bitvector_set_bit() in header for reduced function call overhead in remaining bit operations.

Performance improvements (decompression):
- simple: ~2.5x faster (68µs → 28µs)
- hiro: ~2.6x faster (133µs → 52µs)
- housekeeping: ~2.1x faster (15.4ms → 7.5ms)
- venus-express: ~1.25x faster (305ms → 245ms)

All reference test vectors pass with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)