### PR TITLE
ci: build test binaries in comprehensive-tests jobs (#90)

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -30,10 +30,11 @@ jobs:
 
       - name: Build test binary
         working-directory: implementations/c
-        run: make
+        run: make build/test_malformed
 
       - name: Run malformed input tests
         working-directory: implementations/c
+        shell: bash
         run: |
           echo "## Malformed Input Tests" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -86,10 +87,11 @@ jobs:
 
       - name: Build test binary
         working-directory: implementations/c
-        run: make
+        run: make build/test_robustness
 
       - name: Run robustness tests
         working-directory: implementations/c
+        shell: bash
         run: |
           echo "## Robustness Tests (All R Values)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes #90 — the weekly **Comprehensive Tests** workflow has failed every scheduled run since at least 2026-01-11.

**Root cause:** the `malformed-input-tests` and `robustness-tests` jobs ran bare `make`, but the Makefile default target (`all: $(LIB) $(CLI)`) does not build test binaries. The run-test steps then *silently passed* — `./build/test_X 2>&1 | tee out.txt` masks the missing binary because the default shell has no `pipefail` — and the valgrind step was the first to hard-fail with `No such file or directory`. Net effect: these two suites haven't actually executed in CI since the regression.

**Fix:**
- Build the actual targets via the Makefile pattern rule: `make build/test_malformed` / `make build/test_robustness`
- Add `shell: bash` to the run-test steps so pipelines fail loudly (`-o pipefail`)

## Verification

- `make -n build/test_malformed` / `make -n build/test_robustness` resolve correctly via the `$(BUILD_DIR)/%: $(TEST_DIR)/%.c $(LIB)` pattern rule
- Both binaries build and pass locally (46/46 malformed, 30/30 robustness, part of `make test`)
- Will verify end-to-end with a manual `workflow_dispatch` run after this lands

The remaining bare `make` in the Large-Scale job is intentional — it needs the CLI, which the default target builds (that job passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)