### PR TITLE
docs: link crossvalidation TODOs to tracking issues, refresh status table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,10 @@ pocket-plus/
 │   ├── run_crossvalidation.sh          # Shared runner (parameterized for binary paths)
 │   ├── c/                              # C harness (encoder + decoder + Dockerfile)
 │   ├── sandbox/                        # ESA reference code harness
-│   ├── cpp/                            # C++ harness (TODO)
-│   ├── go/                             # Go harness (TODO)
-│   ├── rust/                           # Rust harness (TODO)
-│   └── java/                           # Java harness (TODO)
+│   ├── cpp/                            # C++ harness (TODO: #93)
+│   ├── go/                             # Go harness (TODO: #93)
+│   ├── rust/                           # Rust harness (TODO: #93)
+│   └── java/                           # Java harness (TODO: #93)
 ├── docs/           # Shared documentation
 └── test-vectors/   # Shared test data
 ```
@@ -177,9 +177,11 @@ The verdict honors the known-failures baseline (`crossvalidation/known-failures.
 3. Add a `<lang>-crossvalidation` service to `docker-compose.yml`
 4. The shared `run_crossvalidation.sh` is language-agnostic — just point `ENCODER_BIN` and `DECODER_BIN` at the compiled binaries
 
+Harness ports for C++/Python/Go/Rust/Java are tracked in issue #93 (blocked on #89; decoder hardening prerequisite in #92) — don't start them without checking those issues first.
+
 ### Test Data
 
-The cross-validation test vectors are **not committed**. Download and extract them at the project root:
+The cross-validation test vectors are **not committed**. Obtain them from ESA's OPS-SAT mission control team and extract them at the project root:
 
 ```bash
 unzip ccsds124_full_crossvalidation_20220309.zip -d ccsds124_full_crossvalidation

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compress
 
 ## Implementations
 
-| Language | Version | Status | Target | Location |
-|----------|---------|--------|--------|----------|
-| C | 1.0.0 | Cross-validated¹ | Embedded / Desktop / Server | [`implementations/c/`](implementations/c/) |
-| C++ | 1.0.0 | Validated² | Embedded / Desktop / Server | [`implementations/cpp/`](implementations/cpp/) |
-| Python | 1.0.0 | Validated² | Embedded Linux / Desktop / Server | [`implementations/python/`](implementations/python/) |
-| Go | 1.0.0 | Validated² | Embedded Linux / Desktop / Server | [`implementations/go/`](implementations/go/) |
-| Rust | 1.0.0 | Validated² | Embedded Linux / Desktop / Server | [`implementations/rust/`](implementations/rust/) |
-| Java | 1.0.0 | Validated² | Embedded Linux / Desktop / Server | [`implementations/java/`](implementations/java/) |
+| Language | Version | Validated¹ | Cross-Validated² | Target | Location |
+|----------|---------|------------|------------------|--------|----------|
+| C | 1.0.0 | Yes | Yes | Embedded / Desktop / Server | [`implementations/c/`](implementations/c/) |
+| C++ | 1.0.0 | Yes | No | Embedded / Desktop / Server | [`implementations/cpp/`](implementations/cpp/) |
+| Python | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/python/`](implementations/python/) |
+| Go | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/go/`](implementations/go/) |
+| Rust | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/rust/`](implementations/rust/) |
+| Java | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/java/`](implementations/java/) |
 
-¹ Validated against the UAB CCSDS 124.0-B-1 cross-validation suite (24,900 vectors): encoder 100%, decoder 89% with [documented gaps](docs/TESTING.md#known-gaps-1863-decoder-vectors) in the accuracy guarantee logic for fuzzed packets.
-² Byte-for-byte validated against the ESA reference via the shared [test vectors](test-vectors/); UAB cross-validation harness not yet implemented.
+¹ Byte-for-byte validated against the ESA reference implementation via the shared [test vectors](test-vectors/).
+² Validated against the UAB CCSDS 124.0-B-1 cross-validation suite (24,900 vectors): encoder 100%, decoder 89% with [documented gaps](docs/TESTING.md#known-gaps-1863-decoder-vectors) in the accuracy guarantee logic for fuzzed packets. Harnesses for the other implementations are tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93).
 
 ### Which implementation should I use?
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compress
 
 | Language | Version | Validated¹ | Cross-Validated² | Target | Location |
 |----------|---------|------------|------------------|--------|----------|
-| C | 1.0.0 | Yes | Yes | Embedded / Desktop / Server | [`implementations/c/`](implementations/c/) |
-| C++ | 1.0.0 | Yes | No | Embedded / Desktop / Server | [`implementations/cpp/`](implementations/cpp/) |
+| C | 1.0.0 | Yes | Yes | Bare-metal Embedded / Embedded Linux / Desktop / Server | [`implementations/c/`](implementations/c/) |
+| C++ | 1.0.0 | Yes | No | Bare-metal Embedded / Embedded Linux / Desktop / Server | [`implementations/cpp/`](implementations/cpp/) |
 | Python | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/python/`](implementations/python/) |
 | Go | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/go/`](implementations/go/) |
 | Rust | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/rust/`](implementations/rust/) |
@@ -50,7 +50,7 @@ The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compress
 
 **For bare-metal embedded systems**: Use the **C** or **C++** implementation. Both are suitable for resource-constrained systems. The C++ implementation is header-only with template-based size optimization and works with `-fno-exceptions -fno-rtti`. The C implementation is optimized for 32-bit microcontrollers (e.g., GomSpace Nanomind 3200 / AVR32 MCU).
 
-**For payload computers**: Python, Go, Rust, and Java can run on embedded Linux systems such as payload processors (e.g., SEPP on OPS-SAT-1). Choose based on your runtime environment and preference.
+**For payload computers**: All implementations run on embedded Linux systems such as payload processors (e.g., SEPP on OPS-SAT-1). Choose based on your runtime environment and preference — C/C++ for the smallest footprint, Python/Go/Rust/Java for ecosystem convenience.
 
 **For ground systems and prototyping**: All implementations produce identical compression output. Use whichever language fits your toolchain.
 

--- a/crossvalidation/README.md
+++ b/crossvalidation/README.md
@@ -11,12 +11,14 @@ crossvalidation/
   known-failures.txt        # Documented-gap baseline (1,863 decoder vectors)
   run_crossvalidation.sh    # Shared runner script (parameterized for binary paths)
   c/                        # C implementation harness
-  cpp/                      # C++ implementation harness (TODO)
-  go/                       # Go implementation harness (TODO)
-  rust/                     # Rust implementation harness (TODO)
-  java/                     # Java implementation harness (TODO)
+  cpp/                      # C++ implementation harness (TODO: #93)
+  go/                       # Go implementation harness (TODO: #93)
+  rust/                     # Rust implementation harness (TODO: #93)
+  java/                     # Java implementation harness (TODO: #93)
   sandbox/                  # Original ESA reference code harness
 ```
+
+Harnesses for the other languages are tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93) — deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/pocket-plus/issues/89)), with decoder bitstream hardening ([#92](https://github.com/tanagraspace/pocket-plus/issues/92)) as a prerequisite.
 
 ## Test Vectors
 
@@ -75,7 +77,7 @@ When a known failure is fixed, remove its line from `known-failures.txt`. Never 
 
 ## Prerequisites
 
-The cross-validation test vector data is **not committed** to this repository. You must obtain it separately:
+The cross-validation test vector data is **not committed** to this repository. You must obtain it separately from ESA's OPS-SAT mission control team:
 
 ```bash
 # From the project root:

--- a/crossvalidation/cpp/README.md
+++ b/crossvalidation/cpp/README.md
@@ -1,3 +1,5 @@
 # POCKET+ C++ Cross-Validation
 
-TODO: Implement cross-validation harness for the C++ implementation.
+TODO: Implement the cross-validation harness for the C++ implementation — tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/pocket-plus/issues/89)).
+
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the C++ implementation — tracked in [#92](https://github.com/tanagraspace/pocket-plus/issues/92).

--- a/crossvalidation/go/README.md
+++ b/crossvalidation/go/README.md
@@ -1,3 +1,5 @@
 # POCKET+ Go Cross-Validation
 
-TODO: Implement cross-validation harness for the Go implementation.
+TODO: Implement the cross-validation harness for the Go implementation — tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/pocket-plus/issues/89)).
+
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Go implementation — tracked in [#92](https://github.com/tanagraspace/pocket-plus/issues/92).

--- a/crossvalidation/java/README.md
+++ b/crossvalidation/java/README.md
@@ -1,3 +1,5 @@
 # POCKET+ Java Cross-Validation
 
-TODO: Implement cross-validation harness for the Java implementation.
+TODO: Implement the cross-validation harness for the Java implementation — tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/pocket-plus/issues/89)).
+
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Java implementation — tracked in [#92](https://github.com/tanagraspace/pocket-plus/issues/92).

--- a/crossvalidation/rust/README.md
+++ b/crossvalidation/rust/README.md
@@ -1,3 +1,5 @@
 # POCKET+ Rust Cross-Validation
 
-TODO: Implement cross-validation harness for the Rust implementation.
+TODO: Implement the cross-validation harness for the Rust implementation — tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/pocket-plus/issues/89)).
+
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Rust implementation — tracked in [#92](https://github.com/tanagraspace/pocket-plus/issues/92).

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Shared documentation for all POCKET+ implementations.
 - [Gotchas](GOTCHAS.md) - Critical pitfalls (read this first!)
 - [Benchmark](BENCHMARK.md) - Performance comparison across implementations
 - [Testing](TESTING.md) - Test report and validation procedures
+- [Cross-Validation](../crossvalidation/README.md) - CCSDS 124.0-B-1 cross-validation suite, runner, and known-failures baseline
 - [Test Vectors](../test-vectors/README.md) - Validation data
 - [Test Vector Generator](../test-vector-generator/README.md) - Deterministic test vector generation
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -303,10 +303,11 @@ Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees 
 
 **16 vectors — unknown excess-rejection rule**: the reference rejects certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
 
-**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in the repository issue tracker; see also GOTCHAS.md #22.
+**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/pocket-plus/issues/89); see also GOTCHAS.md #22.
 
 Other known gaps:
-- Cross-validation harnesses for C++, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders). Those implementations are validated via the shared `test-vectors/` only.
+- Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/pocket-plus/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
+- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #21) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/pocket-plus/issues/92).
 
 ## Run All Tests
 


### PR DESCRIPTION
## Summary

Full markdown review after the #87/#88/#91 wrap-up, plus the requested issue-reference updates for the cross-validation READMEs.

**Cross-validation READMEs (main + sub):**
- The four TODO stub READMEs (`crossvalidation/{cpp,go,rust,java}/`) now link [#93](https://github.com/tanagraspace/pocket-plus/issues/93) (harness ports, deferred until [#89](https://github.com/tanagraspace/pocket-plus/issues/89) resolves) and [#92](https://github.com/tanagraspace/pocket-plus/issues/92) (decoder hardening prerequisite)
- Main `crossvalidation/README.md`: structure-tree TODOs reference #93 with the deferral rationale; test-data prerequisites now say the vectors must be obtained from **ESA's OPS-SAT mission control team**

**Other updates from the review:**
- `README.md`: implementations table restructured — Status split into **Validated¹ / Cross-Validated²** Yes|No columns, superscripts moved to the headers
- `docs/TESTING.md`: known-gaps bullets link #89/#92/#93; added the missing gap that non-C decoders lack bitstream-integrity validation
- `docs/README.md`: cross-validation docs added to the index
- `AGENTS.md`: same data-provenance note, issue refs in the structure tree, and a pointer to #92/#93 in "Adding a New Language Harness"

**Review verdict on everything else:** all other markdowns are current — the historical pass-count progressions in GOTCHAS.md (#21/#22) are intentionally historical, GUIDELINES.md's "22 pitfalls" count is still correct, and the benchmark/test-vector/generator docs are unaffected by recent changes. `sandbox/` markdown copies are stale snapshots by design and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)