### PR TITLE
fix: D0 = 0 per CCSDS Eq. 8 in C++, Python, Go, Rust, and Java (#98)

### DIFF
--- a/implementations/cpp/include/pocketplus/mask.hpp
+++ b/implementations/cpp/include/pocketplus/mask.hpp
@@ -115,8 +115,9 @@ template <std::size_t N>
 void compute_change(BitVector<N>& change, const BitVector<N>& mask, const BitVector<N>& prev_mask,
                     std::size_t t) noexcept {
     if (t == 0) {
-        // At t=0, D_0 = M_0 (all initially predictable bits)
-        change = mask;
+        // CCSDS Eq. 8: D_0 = 0 — no change at initialization; both encoder
+        // and decoder start from the same user-specified M_0
+        change.zero();
     } else {
         // D_t = M_t XOR M_{t-1}
         change.xor_with(mask, prev_mask);

--- a/implementations/cpp/tests/test_compressor.cpp
+++ b/implementations/cpp/tests/test_compressor.cpp
@@ -259,8 +259,8 @@ TEST_CASE("Mask update functions", "[compressor][mask]") {
 
         compute_change(change, mask, prev_mask, 0);
 
-        // At t=0, change = mask
-        REQUIRE(change == mask);
+        // CCSDS Eq. 8: D_0 = 0 regardless of M_0 (no change at initialization)
+        REQUIRE(change.hamming_weight() == 0);
     }
 
     SECTION("compute_change at t>0") {

--- a/implementations/cpp/tests/test_mask.cpp
+++ b/implementations/cpp/tests/test_mask.cpp
@@ -260,12 +260,12 @@ TEST_CASE("Update mask no change", "[mask][mask_update]") {
 // ============================================================================
 
 TEST_CASE("Compute change at t=0", "[mask][change]") {
-    // At t=0, D_t should be M_t
+    // CCSDS Eq. 8: D_0 = 0 regardless of M_0 (no change at initialization)
     BitVector<8> change;
     BitVector<8> mask;
     BitVector<8> prev_mask;
 
-    // Set mask = 0xFF (all ones)
+    // Set mask = 0xFF (all ones) — must NOT leak into D_0
     for (std::size_t i = 0; i < 8; ++i) {
         mask.set_bit(i, 1);
     }
@@ -279,8 +279,8 @@ TEST_CASE("Compute change at t=0", "[mask][change]") {
 
     compute_change(change, mask, prev_mask, 0);
 
-    // At t=0, D_0 = M_0
-    REQUIRE(change.hamming_weight() == 8);
+    // CCSDS Eq. 8: D_0 = 0
+    REQUIRE(change.hamming_weight() == 0);
 }
 
 TEST_CASE("Compute change normal case", "[mask][change]") {

--- a/implementations/go/pocketplus/compressor.go
+++ b/implementations/go/pocketplus/compressor.go
@@ -478,8 +478,9 @@ func updateMaskInternal(mask, inputVec, prevInput, buildPrev, workChanges *BitVe
 
 func computeChangeInternal(change, mask, prevMask *BitVector, t int) {
 	if t == 0 {
-		// At t=0, D0 = M0 (assuming M-1 = 0)
-		change.CopyFrom(mask)
+		// CCSDS Eq. 8: D0 = 0 — both encoder and decoder start from the
+		// same user-specified M0, so there is no change to communicate
+		change.Zero()
 	} else {
 		// Dt = Mt XOR Mt-1
 		change.XORInto(mask, prevMask)

--- a/implementations/go/pocketplus/mask.go
+++ b/implementations/go/pocketplus/mask.go
@@ -52,11 +52,12 @@ func UpdateMask(mask, inputVec, prevInput, buildPrev *BitVector, newMaskFlag boo
 //
 // Equation:
 //   - Dt = Mt XOR Mt-1  (if t > 0)
-//   - Dt = Mt           (if t = 0, assuming M-1 = 0)
+//   - Dt = 0            (if t = 0, CCSDS Eq. 8: no change at initialization)
 func ComputeChange(change, mask, prevMask *BitVector, t int) {
 	if t == 0 {
-		// At t=0, D0 = M0 (assuming M-1 = 0)
-		change.CopyFrom(mask)
+		// CCSDS Eq. 8: D0 = 0 — both encoder and decoder start from the
+		// same user-specified M0, so there is no change to communicate
+		change.Zero()
 	} else {
 		// Dt = Mt XOR Mt-1
 		change.XORInto(mask, prevMask)

--- a/implementations/go/pocketplus/mask_test.go
+++ b/implementations/go/pocketplus/mask_test.go
@@ -104,17 +104,20 @@ func TestUpdateMaskWithNewMaskFlag(t *testing.T) {
 
 func TestComputeChangeInitial(t *testing.T) {
 	change, _ := NewBitVector(8)
+	change.FromBytes([]byte{0xFF}) // Should be overwritten
 	mask, _ := NewBitVector(8)
 	prevMask, _ := NewBitVector(8)
 
 	mask.FromBytes([]byte{0xAB})
 	prevMask.FromBytes([]byte{0xFF}) // Should be ignored at t=0
 
-	// At t=0, change = mask
+	// CCSDS Eq. 8: D0 = 0 regardless of M0 (no change at initialization)
 	ComputeChange(change, mask, prevMask, 0)
 
-	if !change.Equals(mask) {
-		t.Errorf("t=0: change should equal mask, got %v", change.ToBytes())
+	expected, _ := NewBitVector(8)
+	expected.Zero()
+	if !change.Equals(expected) {
+		t.Errorf("t=0: change should be zero per CCSDS Eq. 8, got %v", change.ToBytes())
 	}
 }
 

--- a/implementations/java/src/main/java/space/tanagra/pocketplus/MaskOperations.java
+++ b/implementations/java/src/main/java/space/tanagra/pocketplus/MaskOperations.java
@@ -129,7 +129,9 @@ public final class MaskOperations {
    */
   public static BitVector computeChange(BitVector mask, BitVector prevMask, int t) {
     if (t == 0) {
-      return new BitVector(mask);
+      // CCSDS Eq. 8: D0 = 0 — both encoder and decoder start from the
+      // same user-specified M0, so there is no change to communicate
+      return new BitVector(mask.length());
     } else {
       return mask.xor(prevMask);
     }
@@ -146,7 +148,8 @@ public final class MaskOperations {
   public static void computeChangeInto(
       BitVector result, BitVector mask, BitVector prevMask, int t) {
     if (t == 0) {
-      result.copyFrom(mask);
+      // CCSDS Eq. 8: D0 = 0 — no change at initialization
+      result.zero();
     } else {
       // Dₜ = Mₜ XOR Mₜ₋₁ computed directly into result
       int numWords = result.numWords();

--- a/implementations/java/src/test/java/space/tanagra/pocketplus/MaskOperationsTest.java
+++ b/implementations/java/src/test/java/space/tanagra/pocketplus/MaskOperationsTest.java
@@ -1,0 +1,42 @@
+package space.tanagra.pocketplus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link MaskOperations} (CCSDS 124.0-B-1 Section 4). */
+class MaskOperationsTest {
+
+  /**
+   * Regression test for GOTCHAS #19 (issue #98): CCSDS Eq. 8 defines D0 = 0 regardless of the
+   * initial mask M0 — there is no change to communicate at initialization. The pre-fix behavior (D0
+   * = M0) wrongly encoded a non-zero initial mask as a change.
+   */
+  @Test
+  void computeChangeAtT0IsZero() {
+    BitVector mask = BitVector.fromBytes(new byte[] {(byte) 0xF0}, 8);
+    BitVector prevMask = BitVector.fromBytes(new byte[] {(byte) 0xFF}, 8);
+
+    BitVector change = MaskOperations.computeChange(mask, prevMask, 0);
+    assertEquals(0, change.hammingWeight(), "D0 must be 0 per CCSDS Eq. 8");
+  }
+
+  @Test
+  void computeChangeIntoAtT0IsZero() {
+    BitVector mask = BitVector.fromBytes(new byte[] {(byte) 0xF0}, 8);
+    BitVector prevMask = new BitVector(8);
+    BitVector result = BitVector.fromBytes(new byte[] {(byte) 0xFF}, 8); // must be overwritten
+
+    MaskOperations.computeChangeInto(result, mask, prevMask, 0);
+    assertEquals(0, result.hammingWeight(), "D0 must be 0 per CCSDS Eq. 8");
+  }
+
+  @Test
+  void computeChangeAtTPositiveIsXor() {
+    BitVector mask = BitVector.fromBytes(new byte[] {(byte) 0xCC}, 8);
+    BitVector prevMask = BitVector.fromBytes(new byte[] {(byte) 0xAA}, 8);
+
+    BitVector change = MaskOperations.computeChange(mask, prevMask, 1);
+    assertEquals(4, change.hammingWeight(), "Dt = Mt XOR Mt-1 (0xCC ^ 0xAA = 0x66)");
+  }
+}

--- a/implementations/python/pocketplus/mask.py
+++ b/implementations/python/pocketplus/mask.py
@@ -102,7 +102,7 @@ def compute_change(
 
     Equation:
     - Dt = Mt XOR Mt-1  (if t > 0)
-    - Dt = Mt           (if t = 0, assuming M-1 = 0)
+    - Dt = 0            (if t = 0, CCSDS Eq. 8: no change at initialization)
 
     Args:
         change: Change vector to compute (modified in place)
@@ -111,8 +111,9 @@ def compute_change(
         t: Current time step
     """
     if t == 0:
-        # At t=0, D0 = M0 (assuming M-1 = 0)
-        change.copy_from(mask)
+        # CCSDS Eq. 8: D0 = 0 — both encoder and decoder start from the
+        # same user-specified M0, so there is no change to communicate
+        change.zero()
     else:
         # Dt = Mt XOR Mt-1
         change.xor(mask, prev_mask)

--- a/implementations/python/tests/test_compress.py
+++ b/implementations/python/tests/test_compress.py
@@ -349,3 +349,34 @@ class TestEffectiveRobustnessCap:
         # Rt=7, Ct can be up to (15-Rt)=8
         # So Vt = Rt + Ct = 7 + 8 = 15 (max)
         assert Vt == 15
+
+
+class TestNonZeroInitialMask:
+    """Regression tests for GOTCHAS #19: D0 = 0 per CCSDS Eq. 8 (issue #98)."""
+
+    def test_first_packet_starts_with_rle_terminator(self) -> None:
+        """With a non-zero M0, the first packet must still encode X0 = 0.
+
+        CCSDS Eq. 8 defines D0 = 0, so RLE(X0) is just the terminator '10'.
+        The pre-fix behavior (D0 = M0) wrongly encoded the initial mask as a
+        change, producing '11...' as the first bits.
+        """
+        initial_mask = BitVector(16)
+        initial_mask.from_bytes(bytes([0xFF, 0x00]))
+        comp = Compressor(
+            packet_length=16,
+            robustness=1,
+            initial_mask=initial_mask,
+            pt_limit=10,
+            ft_limit=20,
+            rt_limit=50,
+        )
+
+        input_data = BitVector(16)
+        input_data.from_bytes(bytes([0xAB, 0xCD]))
+        output = comp.compress_packet(input_data)
+
+        # First two bits of h0 are RLE(X0) = '10' (terminator only)
+        first_byte = output[0]
+        assert (first_byte >> 7) & 1 == 1
+        assert (first_byte >> 6) & 1 == 0

--- a/implementations/python/tests/test_mask.py
+++ b/implementations/python/tests/test_mask.py
@@ -136,8 +136,9 @@ class TestComputeChange:
     """Test change vector computation (CCSDS Equation 8)."""
 
     def test_compute_change_t0(self) -> None:
-        """Test change at t=0 equals mask."""
+        """Test change at t=0 is zero (CCSDS Eq. 8: D0 = 0)."""
         change = BitVector(8)
+        change.from_bytes(bytes([0xFF]))  # Should be overwritten
         mask = BitVector(8)
         mask.from_bytes(bytes([0b11110000]))
         prev_mask = BitVector(8)
@@ -145,8 +146,8 @@ class TestComputeChange:
 
         compute_change(change, mask, prev_mask, t=0)
 
-        # At t=0, change = mask
-        assert change.to_bytes() == bytes([0b11110000])
+        # CCSDS Eq. 8: D0 = 0 regardless of M0 (no change at initialization)
+        assert change.to_bytes() == bytes([0x00])
 
     def test_compute_change_t_positive(self) -> None:
         """Test change at t>0 is XOR of masks."""

--- a/implementations/rust/src/mask.rs
+++ b/implementations/rust/src/mask.rs
@@ -86,7 +86,7 @@ pub fn update_mask(
 ///
 /// CCSDS Equation 8:
 /// - Dₜ = Mₜ XOR Mₜ₋₁ (if t > 0)
-/// - Dₜ = Mₜ (if t = 0, assuming M₋₁ = 0)
+/// - Dₜ = 0 (if t = 0: no change at initialization)
 ///
 /// The change vector tracks which mask bits changed between time steps.
 /// This is used in encoding to communicate mask updates.
@@ -100,8 +100,11 @@ pub fn update_mask(
 /// The change vector Dₜ
 pub fn compute_change(mask: &BitVector, prev_mask: &BitVector, t: usize) -> BitVector {
     if t == 0 {
-        // At t=0, D₀ = M₀ (all initially predictable bits)
-        mask.clone()
+        // CCSDS Eq. 8: D₀ = 0 — both encoder and decoder start from the
+        // same user-specified M₀, so there is no change to communicate
+        let mut zero = mask.clone();
+        zero.zero();
+        zero
     } else {
         // Dₜ = Mₜ XOR Mₜ₋₁
         mask.xor(prev_mask)
@@ -187,8 +190,8 @@ mod tests {
 
         let change = compute_change(&mask, &prev_mask, 0);
 
-        // At t=0, change = mask
-        assert_eq!(change, mask);
+        // CCSDS Eq. 8: D0 = 0 regardless of M0 (no change at initialization)
+        assert_eq!(change, BitVector::new(8));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #98 — ports the **GOTCHAS #19 fix** (D₀ = 0, CCSDS Eq. 8) from the C implementation to the five ports, which all set `D₀ = M₀` and would produce non-conformant, C-incompatible output for any non-zero initial mask.

## Why this was latent

- Every unit test and all five shared test vectors use M₀ = 0, where `D₀ = M₀` coincides with the correct value
- Four of the five languages had unit tests **asserting the buggy behavior** (`at t=0, change = mask`) — faithfully ported from the pre-fix C code
- The only data that exercises non-zero M₀ is the CCSDS cross-validation suite, which only the C implementation runs (it's how the bug was found and fixed in C in February)

## Changes

| Language | Fix | Tests |
|---|---|---|
| C++ | `mask.hpp` `compute_change`: `change.zero()` at t=0 | 2 stale assertions corrected (`test_mask.cpp`, `test_compressor.cpp`) |
| Python | `mask.py` `compute_change`: `change.zero()` | stale assertion corrected + **new end-to-end test**: non-zero M₀ → first packet starts with RLE(X₀)=`'10'` (verified to fail pre-fix) |
| Go | `mask.go` `ComputeChange` **and** `compressor.go` `computeChangeInternal` (duplicated logic) | stale assertion corrected |
| Rust | `mask.rs` `compute_change` | stale assertion corrected |
| Java | `MaskOperations.computeChange` **and** `computeChangeInto` | **new `MaskOperationsTest`** (the class had no computeChange coverage at all) |

## Verification

- C++: 663 assertions / 110 cases via Docker — pass
- Python: 186 tests — pass (incl. new regression test)
- Go: `go test ./...` — pass
- Rust: 95 tests — pass
- Java: 89 tests — pass (incl. 3 new)
- Reference test vectors unaffected: with M₀ = 0 the output is byte-identical before and after the fix

Found by the spec-conformance audit of all six implementations against the CCSDS 124.0-B-1 PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)