### PR TITLE
fix: enforce CCSDS F range (1..65535) in Python and Go; document Rust byte-multiple restriction (#99)

### DIFF
--- a/implementations/go/pocketplus/compress_test.go
+++ b/implementations/go/pocketplus/compress_test.go
@@ -521,3 +521,23 @@ func TestCompressPacketNilInput(t *testing.T) {
 		t.Error("Expected error for nil input")
 	}
 }
+
+// TestPacketLengthBounds verifies CCSDS 124.0-B-1 section 3.2:
+// 1 <= F <= 65535 (issue #99).
+func TestPacketLengthBounds(t *testing.T) {
+	if _, err := NewCompressor(0, nil, 1, 0, 0, 0); err == nil {
+		t.Error("NewCompressor should reject F=0")
+	}
+	if _, err := NewCompressor(MaxPacketLength+1, nil, 1, 0, 0, 0); err == nil {
+		t.Error("NewCompressor should reject F>65535")
+	}
+	if _, err := NewCompressor(MaxPacketLength, nil, 1, 0, 0, 0); err != nil {
+		t.Errorf("NewCompressor should accept F=65535: %v", err)
+	}
+	if _, err := NewDecompressor(0, nil, 1); err == nil {
+		t.Error("NewDecompressor should reject F=0")
+	}
+	if _, err := NewDecompressor(MaxPacketLength+1, nil, 1); err == nil {
+		t.Error("NewDecompressor should reject F>65535")
+	}
+}

--- a/implementations/go/pocketplus/compressor.go
+++ b/implementations/go/pocketplus/compressor.go
@@ -7,9 +7,10 @@ import (
 
 // Constants
 const (
-	MaxHistory    = 16 // History depth for change vectors
-	MaxVtHistory  = 16 // History size for Vt calculation
-	MaxRobustness = 7  // Maximum robustness level
+	MaxHistory      = 16    // History depth for change vectors
+	MaxVtHistory    = 16    // History size for Vt calculation
+	MaxRobustness   = 7     // Maximum robustness level
+	MaxPacketLength = 65535 // CCSDS 124.0-B-1 section 3.2: 1 <= F <= 2^16 - 1
 )
 
 // CompressParams holds compression parameters for a single packet.
@@ -68,8 +69,8 @@ type Compressor struct {
 
 // NewCompressor creates a new compressor.
 func NewCompressor(F int, initialMask *BitVector, robustness, ptLimit, ftLimit, rtLimit int) (*Compressor, error) {
-	if F <= 0 {
-		return nil, errors.New("F must be positive")
+	if F <= 0 || F > MaxPacketLength {
+		return nil, fmt.Errorf("F must be between 1 and %d bits", MaxPacketLength)
 	}
 	if robustness < 0 || robustness > MaxRobustness {
 		return nil, fmt.Errorf("robustness must be between 0 and %d", MaxRobustness)

--- a/implementations/go/pocketplus/decompressor.go
+++ b/implementations/go/pocketplus/decompressor.go
@@ -23,8 +23,8 @@ type Decompressor struct {
 
 // NewDecompressor creates a new decompressor.
 func NewDecompressor(F int, initialMask *BitVector, robustness int) (*Decompressor, error) {
-	if F <= 0 {
-		return nil, errors.New("F must be positive")
+	if F <= 0 || F > MaxPacketLength {
+		return nil, fmt.Errorf("F must be between 1 and %d bits", MaxPacketLength)
 	}
 	if robustness < 0 || robustness > MaxRobustness {
 		return nil, fmt.Errorf("robustness must be between 0 and %d", MaxRobustness)

--- a/implementations/python/pocketplus/compress.py
+++ b/implementations/python/pocketplus/compress.py
@@ -17,6 +17,7 @@ if False:  # noqa: SIM108
 MAX_HISTORY = 16
 MAX_VT_HISTORY = 16
 MAX_ROBUSTNESS = 7
+MAX_PACKET_LENGTH = 65535  # CCSDS 124.0-B-1 section 3.2: 1 <= F <= 2^16 - 1
 
 
 class CompressParams:
@@ -68,6 +69,12 @@ class Compressor:
             rt_limit: Uncompressed period (0 = manual control)
         """
         from pocketplus.bitvector import BitVector
+
+        # CCSDS 124.0-B-1 section 3.2: 1 <= F <= 2^16 - 1
+        if packet_length < 1 or packet_length > MAX_PACKET_LENGTH:
+            raise ValueError(
+                "packet_length must be in 1.." + str(MAX_PACKET_LENGTH) + " bits"
+            )
 
         self.F = packet_length
         self.robustness = min(robustness, MAX_ROBUSTNESS)

--- a/implementations/python/pocketplus/decompress.py
+++ b/implementations/python/pocketplus/decompress.py
@@ -15,6 +15,7 @@ if False:  # noqa: SIM108
 
 # Constants
 MAX_ROBUSTNESS = 7
+MAX_PACKET_LENGTH = 65535  # CCSDS 124.0-B-1 section 3.2: 1 <= F <= 2^16 - 1
 
 
 class Decompressor:
@@ -35,6 +36,12 @@ class Decompressor:
             initial_mask: M0 - Initial mask vector (None = all zeros)
         """
         from pocketplus.bitvector import BitVector
+
+        # CCSDS 124.0-B-1 section 3.2: 1 <= F <= 2^16 - 1
+        if packet_length < 1 or packet_length > MAX_PACKET_LENGTH:
+            raise ValueError(
+                "packet_length must be in 1.." + str(MAX_PACKET_LENGTH) + " bits"
+            )
 
         self.F = packet_length
         self.robustness = min(robustness, MAX_ROBUSTNESS)

--- a/implementations/python/tests/test_compress.py
+++ b/implementations/python/tests/test_compress.py
@@ -380,3 +380,19 @@ class TestNonZeroInitialMask:
         first_byte = output[0]
         assert (first_byte >> 7) & 1 == 1
         assert (first_byte >> 6) & 1 == 0
+
+
+class TestPacketLengthValidation:
+    """CCSDS 124.0-B-1 section 3.2: 1 <= F <= 65535 (issue #99)."""
+
+    def test_rejects_zero_packet_length(self) -> None:
+        with pytest.raises(ValueError):
+            Compressor(packet_length=0)
+
+    def test_rejects_oversized_packet_length(self) -> None:
+        with pytest.raises(ValueError):
+            Compressor(packet_length=65536)
+
+    def test_accepts_boundary_packet_lengths(self) -> None:
+        assert Compressor(packet_length=1).F == 1
+        assert Compressor(packet_length=65535).F == 65535

--- a/implementations/python/tests/test_decompress.py
+++ b/implementations/python/tests/test_decompress.py
@@ -1,5 +1,7 @@
 """Tests for POCKET+ decompression."""
 
+import pytest
+
 from pocketplus.bitvector import BitVector
 from pocketplus.compress import compress
 from pocketplus.decompress import Decompressor, decompress
@@ -314,3 +316,15 @@ class TestVtZeroMaskToggle:
         )
 
         assert decompressed == original
+
+
+class TestDecompressorPacketLengthValidation:
+    """CCSDS 124.0-B-1 section 3.2: 1 <= F <= 65535 (issue #99)."""
+
+    def test_rejects_zero_packet_length(self) -> None:
+        with pytest.raises(ValueError):
+            Decompressor(packet_length=0)
+
+    def test_rejects_oversized_packet_length(self) -> None:
+        with pytest.raises(ValueError):
+            Decompressor(packet_length=65536)

--- a/implementations/rust/README.md
+++ b/implementations/rust/README.md
@@ -84,6 +84,8 @@ let compressed = compress(
 let decompressed = decompress(&compressed, 720, 1).unwrap();
 ```
 
+**Note:** the high-level `compress()`/`decompress()` byte-buffer APIs require `packet_size` to be a multiple of 8 bits. The CCSDS 124.0-B-1 standard allows any F in 1..=65535 bits — use the low-level `Compressor`/`Decompressor` for non-byte-aligned packet lengths.
+
 ## Design
 
 - **Zero dependencies** - Rust standard library only

--- a/implementations/rust/src/compress.rs
+++ b/implementations/rust/src/compress.rs
@@ -320,6 +320,11 @@ impl Compressor {
 }
 
 /// Compress multiple packets of housekeeping data.
+///
+/// This byte-buffer convenience API requires `packet_size` (in bits) to be a
+/// multiple of 8 so packets map cleanly onto the input byte slice. The CCSDS
+/// 124.0-B-1 standard itself allows any F in 1..=65535 bits — use the
+/// low-level [`Compressor`] for non-byte-aligned packet lengths.
 pub fn compress(
     data: &[u8],
     packet_size: usize,

--- a/implementations/rust/src/decompress.rs
+++ b/implementations/rust/src/decompress.rs
@@ -240,6 +240,11 @@ impl Decompressor {
 /// - `packet_size` is 0 or not divisible by 8
 /// - `robustness` is greater than 7
 /// - Compressed data is invalid or corrupted
+///
+/// This byte-buffer convenience API requires `packet_size` (in bits) to be a
+/// multiple of 8. The CCSDS 124.0-B-1 standard itself allows any F in
+/// 1..=65535 bits — use the low-level [`Decompressor`] for non-byte-aligned
+/// packet lengths.
 pub fn decompress(
     data: &[u8],
     packet_size: usize,


### PR DESCRIPTION
## Summary

Fixes #99 — closes the remaining parameter-validation gaps from the spec-conformance audit. CCSDS 124.0-B-1 §3.2 requires **1 ≤ F ≤ 2¹⁶−1** (and `COUNT(F)` is undefined beyond it).

## Changes

| Language | Change |
|---|---|
| **Python** | `Compressor`/`Decompressor` now raise `ValueError` for `packet_length` outside 1..65535 (there was previously **no validation at all**); new `MAX_PACKET_LENGTH` constant; boundary tests (0, 1, 65535, 65536) |
| **Go** | `NewCompressor`/`NewDecompressor` now reject `F > MaxPacketLength` (previously only `F > 0`); new constant; bounds test covering both constructors |
| **Rust** | No code change needed — low-level API already validates 1..=65535. The high-level byte-buffer APIs' `% 8` requirement is now documented in the rustdoc and README, pointing to `Compressor`/`Decompressor` for non-byte-aligned F |

## Verification

- Python: 191 tests pass, ruff check + format clean
- Go: `go test ./...` pass, gofmt + vet clean
- Rust: 95 tests pass, clippy clean

Found during the same audit as #98 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)