### PR TITLE
fix: MSB-aligned NOT masking for non-byte-aligned F in Python, Rust, Java (#103)

### DIFF
--- a/implementations/java/src/main/java/space/tanagra/pocketplus/BitVector.java
+++ b/implementations/java/src/main/java/space/tanagra/pocketplus/BitVector.java
@@ -191,12 +191,14 @@ public final class BitVector {
       int bytesInLastWord = ((numBytes - 1) % 4) + 1;
       int bitsInLastByte = length - ((numBytes - 1) * 8);
 
-      // Create mask for valid bits in big-endian word
+      // Create mask for valid bits in big-endian word.
+      // MSB-first: valid bits in a partial last byte are at the HIGH end of
+      // the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
       int mask = 0;
       for (int b = 0; b < bytesInLastWord; b++) {
         int byteMask;
         if (b == bytesInLastWord - 1) {
-          byteMask = (1 << bitsInLastByte) - 1;
+          byteMask = (0xFF << (8 - bitsInLastByte)) & 0xFF;
         } else {
           byteMask = 0xFF;
         }

--- a/implementations/java/src/test/java/space/tanagra/pocketplus/BitVectorTest.java
+++ b/implementations/java/src/test/java/space/tanagra/pocketplus/BitVectorTest.java
@@ -110,6 +110,19 @@ class BitVectorTest {
     assertEquals(0, result.getBit(7));
   }
 
+  // GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set the
+  // valid (high) bits and leave padding zero. NOT of an all-zero length-12
+  // vector: positions 0..12 must all be 1.
+  @Test
+  void testNotMsbAlignedNonByteAligned() {
+    BitVector bv = new BitVector(12);
+    BitVector result = bv.not();
+    for (int i = 0; i < 12; i++) {
+      assertEquals(1, result.getBit(i), "position " + i + " should be set");
+    }
+    assertEquals(12, result.hammingWeight());
+  }
+
   @Test
   void testLeftShift() {
     // MSB-first: leftShift moves bits towards bit 0, bit 0 is lost

--- a/implementations/python/pocketplus/bitvector.py
+++ b/implementations/python/pocketplus/bitvector.py
@@ -275,11 +275,13 @@ class BitVector:
             bytes_in_last_word = ((num_bytes - 1) % 4) + 1
             bits_in_last_byte = self.length - ((num_bytes - 1) * 8)
 
-            # Create mask for valid bits in big-endian word
+            # Create mask for valid bits in big-endian word.
+            # MSB-first: valid bits in a partial last byte are at the HIGH
+            # end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
             mask = 0
             for byte in range(bytes_in_last_word):
                 if byte == bytes_in_last_word - 1:
-                    byte_mask = (1 << bits_in_last_byte) - 1
+                    byte_mask = (0xFF << (8 - bits_in_last_byte)) & 0xFF
                 else:
                     byte_mask = 0xFF
                 shift_amt = (3 - byte) * 8

--- a/implementations/python/tests/test_bitvector.py
+++ b/implementations/python/tests/test_bitvector.py
@@ -177,6 +177,19 @@ class TestBitVectorBitwiseOps:
         for i in range(4):
             assert result.get_bit(i) == 0
 
+    def test_not_msb_aligned_non_byte_aligned(self) -> None:
+        """GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set
+        the valid (high) bits and leave padding zero.
+
+        NOT of an all-zero length-12 vector: positions 0..11 must all be 1.
+        The pre-fix bug used a low-bits mask, leaving positions 8..11 at 0 and
+        wrongly setting padding bits 12..15.
+        """
+        a = BitVector(12)  # all zeros
+        result = a.not_()
+        assert [result.get_bit(i) for i in range(12)] == [1] * 12
+        assert result.hamming_weight() == 12
+
     def test_not_multi_byte_partial(self) -> None:
         """Test NOT with multiple bytes where last byte is partial.
 

--- a/implementations/rust/src/bitvector.rs
+++ b/implementations/rust/src/bitvector.rs
@@ -281,7 +281,9 @@ impl BitVector {
             let bytes_in_last_word = ((num_bytes - 1) % 4) + 1;
             let bits_in_last_byte = self.length - ((num_bytes - 1) * 8);
 
-            // Create mask for valid bits in big-endian word
+            // Create mask for valid bits in big-endian word.
+            // MSB-first: valid bits in a partial last byte are at the HIGH
+            // end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
             let mut mask = 0u32;
             for byte in 0..bytes_in_last_word {
                 let byte_mask: u8 = if byte == bytes_in_last_word - 1 {
@@ -289,7 +291,7 @@ impl BitVector {
                     if bits_in_last_byte >= 8 {
                         0xFF
                     } else {
-                        ((1u32 << bits_in_last_byte) - 1) as u8
+                        (0xFFu32 << (8 - bits_in_last_byte)) as u8
                     }
                 } else {
                     0xFF
@@ -479,6 +481,19 @@ mod tests {
         assert_eq!(result.get_bit(1), 1);
         assert_eq!(result.get_bit(2), 0);
         assert_eq!(result.get_bit(3), 1);
+    }
+
+    // GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set the
+    // valid (high) bits and leave padding zero. NOT of an all-zero length-12
+    // vector: positions 0..12 must all be 1.
+    #[test]
+    fn test_not_msb_aligned_non_byte_aligned() {
+        let bv = BitVector::new(12);
+        let result = bv.not();
+        for i in 0..12 {
+            assert_eq!(result.get_bit(i), 1, "position {i} should be set");
+        }
+        assert_eq!(result.hamming_weight(), 12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #103 — ports the **GOTCHAS #20** fix (MSB-aligned NOT masking) from C/C++/Go to Python, Rust, and Java, found by the ALGORITHM.md conformance audit.

POCKET+ is MSB-first, so the valid bits of a non-byte-aligned vector are the **high** bits of the last byte. Correct last-byte mask: `0xFF << (8 - bits_in_last_byte)`. The three ports used `(1 << bits) - 1` (low-bits), zeroing valid bits and setting padding bits.

## Evidence

NOT of an all-zero length-12 vector:
- Buggy: raw word `0xFF0F0000` (positions 8–11 wrongly 0, padding 12–15 wrongly 1)
- Fixed: `0xFFF00000` (positions 0–11 set, padding clean) — matches C

## Why it was latent

All shared test vectors use byte-aligned F=720 (`bits=8` → mask `0xFF`, correct). The defect is **interoperability**: for non-byte-aligned F, these three produced a different `~Mₜ` than the C reference, so their `kₜ = BE(<~Mₜ>, Xₜ)` encoding could diverge from the reference and the other languages. Same latent-port pattern as #98 (D₀).

## Changes

| File | Fix |
|---|---|
| `python/pocketplus/bitvector.py` `not_()` | `(1<<bits)-1` → `(0xFF << (8-bits)) & 0xFF` |
| `rust/src/bitvector.rs` `not()` | same |
| `java/.../BitVector.java` `not()` | same |

Each gains a regression test: NOT of a length-12 zero vector → positions 0–11 set, padding zero. (The existing partial-byte tests passed despite the bug because they only checked valid bits that happened to be 0.)

Also verified: left-shift masking is correct in all three (it only ever operates on clean masks); C/C++/Go were already correct (C++ `not_of`/`invert` apply `mask_unused_bits`).

## Verification

Python 193 ✓ (ruff clean), Rust 86 ✓ (clippy clean), Java 91 ✓ (spotless applied). Reference test vectors (byte-aligned) unaffected in all languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)