### PR TITLE
docs: drop defunct ESA URL from provenance; describe the ESA reference implementation (#110)

### DIFF
--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -526,7 +526,7 @@ Time t=2:
 
 - **CCSDS 124.0-B-1**: Robust Compression of Fixed-Length Housekeeping Data, February 2023
 - **Standard PDF**: https://ccsds.org/Pubs/124x0b1.pdf
-- **ESA Reference Implementation**: provided by ESA (the former opssat.esa.int/pocket-plus page is now defunct)
+- **ESA Reference Implementation**: ESA's barebone C implementation of CCSDS 124.0-B-1 — the byte-for-byte validation baseline and test-vector generator (see `test-vector-generator/c-reference/`)
 - **Implementation Paper**: Evans, D., et al. (2022). "Implementing the New CCSDS Housekeeping Data Compression Standard 124.0-B-1 (based on POCKET+) on OPS-SAT-1."
 
 ## Glossary

--- a/test-vector-generator/README.md
+++ b/test-vector-generator/README.md
@@ -358,7 +358,7 @@ cat output/vectors/simple/metadata.json | jq .results
 
 ## References
 
-- **ESA Source**: https://opssat.esa.int/pocket-plus/ (now defunct as of June 2026); see CCSDS 124.0-B-1 below
+- **ESA Source**: Barebone C reference implementation provided by ESA
 - **CCSDS 124.0-B-1**: Robust Compression of Fixed-Length Housekeeping Data. https://ccsds.org/Pubs/124x0b1.pdf
 - **Implementation Paper**: Evans, D., et al. (2022). "Implementing the New CCSDS Housekeeping Data Compression Standard 124.0-B-1 (based on POCKET+) on OPS-SAT-1." 36th Annual Small Satellite Conference. https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=5292&context=smallsat
 - **Venus Express**: ESA mission to Venus (2005-2015, atmospheric entry January 2015)

--- a/test-vector-generator/c-reference/PROVENANCE.md
+++ b/test-vector-generator/c-reference/PROVENANCE.md
@@ -2,7 +2,6 @@
 
 ## Source
 
-- **URL**: https://opssat.esa.int/pocket-plus/ (now defunct as of June 2026)
 - **Obtained**: December 2, 2024
 - **Description**: Barebone C reference implementation provided by ESA
 


### PR DESCRIPTION
Follow-up to #110 (merged).

Per feedback: instead of annotating the dead `opssat.esa.int/pocket-plus` URL as "now defunct", **drop the URL entirely**, and where we mention the "ESA Reference Implementation", **describe what it is** rather than link to it.

- `PROVENANCE.md` / `test-vector-generator/README.md`: removed the dead URL from the source/provenance records (ESA attribution retained via the Description).
- `docs/ALGORITHM.md` References: replaced the dangling pointer with a description — "ESA's barebone C implementation of CCSDS 124.0-B-1 — the byte-for-byte validation baseline and test-vector generator (see `test-vector-generator/c-reference/`)".

No `opssat.esa.int/pocket-plus` references remain in tracked source. Ready for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)