### PR TITLE
fix: remove residual CCSDS 124.0-B-1 brand duplication in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance for AI agents (like Claude Code) working on the CCSD
 
 ## Project Overview
 
-CCSDS 124.0-B-1 is a multi-language implementation of the CCSDS 124.0-B-1 lossless compression algorithm designed for spacecraft housekeeping data. This is a **monorepo** with independent implementations in C, C++, Python, Go, Rust, and Java.
+This repository provides multi-language implementations of the CCSDS 124.0-B-1 lossless compression algorithm designed for spacecraft housekeeping data. This is a **monorepo** with independent implementations in C, C++, Python, Go, Rust, and Java.
 
 ## Repository Structure
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
     <p>Lossless compression for satellite housekeeping telemetry data.</p>
   </header>
   <div class="content">
-    <p>The definitive implementation of the <a href="https://ccsds.org/Pubs/124x0b1.pdf">CCSDS 124.0-B-1</a> CCSDS 124.0-B-1 lossless compression algorithm of fixed-length housekeeping data.</p>
+    <p>The definitive implementation of the <a href="https://ccsds.org/Pubs/124x0b1.pdf">CCSDS 124.0-B-1</a> lossless compression algorithm of fixed-length housekeeping data.</p>
     <br>
     <p>CCSDS 124.0-B-1 is patented by the <a href="https://www.esa.int/">European Space Agency (ESA)</a>, standardized by the <a href="https://ccsds.org/">Consultative Committee for Space Data Systems (CCSDS)</a>, and implemented by <a href="https://georges.fyi">georges.fyi</a> at <a href="https://tanagraspace.com/">Tanagra Space</a>.</p>
 

--- a/implementations/java/src/main/java/space/tanagra/ccsds124/Compressor.java
+++ b/implementations/java/src/main/java/space/tanagra/ccsds124/Compressor.java
@@ -6,7 +6,7 @@
 package space.tanagra.ccsds124;
 
 /**
- * CCSDS 124.0-B-1 compressor implementing CCSDS 124.0-B-1 Section 5.3.
+ * Compressor implementing CCSDS 124.0-B-1 Section 5.3.
  *
  * <p>Output packet format: oₜ = hₜ ∥ qₜ ∥ uₜ
  *


### PR DESCRIPTION
Cleans up three adjacent/near-adjacent "CCSDS 124.0-B-1 CCSDS 124.0-B-1" repeats left by the rebrand bulk-replace that the earlier collapse passes missed:

- **`docs/index.html`** — the website's first sentence ("...the CCSDS 124.0-B-1 CCSDS 124.0-B-1 lossless compression algorithm"). The two were separated by a `</a>` tag, so the plain-space collapse didn't catch it.
- **`AGENTS.md`** — self-referential "CCSDS 124.0-B-1 is a multi-language implementation of the CCSDS 124.0-B-1 lossless...".
- **`Compressor.java`** javadoc — "CCSDS 124.0-B-1 compressor implementing CCSDS 124.0-B-1 Section 5.3" (keeps the spec-section reference).

Verified zero remaining repeats repo-wide (any separator, including HTML tags and newlines).

### Note on the deployed coverage/test reports
The `pocket-plus` strings on the live Rust/Python (and all other) coverage/test reports are the **GitHub Actions runner workspace path** (`/home/runner/work/pocket-plus/pocket-plus/...`) baked in by a deploy that ran **before** the repo was renamed. They are not produced by any committed source. Merging this PR triggers a fresh post-rename deploy, which rebuilds those reports with `/home/runner/work/ccsds124/ccsds124/...` — removing `pocket-plus` everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)