### PR TITLE
docs: remove redundant GOTCHA #4, renumber 5-22 to 4-21, and correct/de-duplicate the docs

### DIFF
--- a/crossvalidation/cpp/README.md
+++ b/crossvalidation/cpp/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the C++ implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the C++ implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the C++ implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).

--- a/crossvalidation/go/README.md
+++ b/crossvalidation/go/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Go implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Go implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Go implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).

--- a/crossvalidation/java/README.md
+++ b/crossvalidation/java/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Java implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Java implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Java implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).

--- a/crossvalidation/known-failures.txt
+++ b/crossvalidation/known-failures.txt
@@ -1,6 +1,6 @@
 # CCSDS 124.0-B-1 cross-validation known-failures baseline
 # These decoder vectors are documented gaps in the accuracy guarantee
-# accept/reject logic (see docs/TESTING.md 'Known Gaps' and GOTCHAS.md #22).
+# accept/reject logic (see docs/TESTING.md 'Known Gaps' and GOTCHAS.md #21).
 # The runner passes when actual failures match this list exactly.
 # Remove entries as they are fixed; never add entries without investigation.
 decoder_sequence_08724.raw+large_f

--- a/crossvalidation/rust/README.md
+++ b/crossvalidation/rust/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Rust implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #21) to the Rust implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Rust implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -13,120 +13,9 @@ CCSDS 124.0-B-1 is a lossless compression algorithm designed for fixed-length ho
 
 ## ⚠️ Critical Implementation Notes
 
-**READ THIS FIRST!** These are the most common implementation pitfalls that will cause your output to diverge from the reference implementation:
+Implementing this algorithm has several non-obvious pitfalls that cause divergence from the reference: the Rₜ+1 initialization phase, flag timing (countdown counters, with the first trigger at `period + 1` because the first packet is the initialization packet), the Vₜ change-history window, D₀ = 0 at initialization, kₜ inversion and forward extraction order, MSB-aligned masking for non-byte-aligned lengths, and decoder bitstream validation.
 
-### 1. Initialization Phase: First Rₜ+1 Packets (Not Rₜ+2!)
-
-The CCSDS spec (Section 3.3.2 c–d) mandates ḟₜ=1 and ṙₜ=1 for the **first Rₜ+1 packets** (t ≤ Rₜ). The spec leaves ṗₜ user-specified at every t; the reference implementation additionally uses ṗₜ=0 during initialization, and matching it is required for byte-identical output.
-
-**Example for Rₜ=1:**
-- Packet 0 (first packet): init phase → ḟₜ=1, ṙₜ=1, ṗₜ=0
-- Packet 1 (second packet): init phase → ḟₜ=1, ṙₜ=1, ṗₜ=0
-- Packet 2 (third packet): **normal operation begins**
-
-**Common mistake:** Applying init phase to Rₜ+2 packets instead of Rₜ+1 packets.
-
-**Correct condition:** `packet_index ≤ Rₜ` triggers init phase
-**Wrong condition:** `packet_index < Rₜ + 2` (applies to 3 packets when Rₜ=1)
-
-### 2. Flag Timing: Countdown Counters, Not Modulo Arithmetic
-
-The reference implementation uses **countdown counters** that start at the period limit and decrement each packet. Flags trigger when the counter reaches 1, then reset.
-
-**Pattern for Rₜ=1, periods (10, 20, 50):**
-- ṗₜ=1 (new mask) at packets: **11, 21, 31, 41...** (not 10, 20, 30!)
-- ḟₜ=1 (send mask) at packets: **21, 41, 61, 81...** (not 20, 40, 60!)
-- ṙₜ=1 (uncompressed) at packets: **51, 101, 151, 201...** (not 50, 100, 150!)
-
-**Key insight:** First trigger happens at `period + Rₜ`, not at `period`.
-
-**Example for pt_period=10, Rₜ=1:**
-- pt_first_trigger = 10 + 1 = **packet 11**
-- Subsequent triggers: packets 21, 31, 41... (every 10 packets)
-
-**Common mistake:** Using `(packet_num % period) == 0` which triggers one packet too early (at packets 10, 20, 30 instead of 11, 21, 31).
-
-### 3. Vₜ Calculation: Start from Rₜ+1
-
-Per CCSDS Section 5.3.2.2 (NOTE to Equation 14), Cₜ counts consecutive occurrences of no mask changes, starting from the first cycle not covered by Rₜ — i.e., Rₜ+1 cycles back — and working backwards in time.
-
-**Correct algorithm:**
-1. For t ≤ Rₜ: Vₜ = Rₜ (initialization phase)
-2. For t > Rₜ: Count backward starting from position Rₜ+1
-   - Check D_{t-(Rₜ+1)}, D_{t-(Rₜ+2)}, ...
-   - Stop when finding a change or reaching the maximum Cₜ = min(t, 15) - Rₜ (Eq. 14)
-   - Vₜ = Rₜ + Cₜ
-
-**Example for Rₜ=2, t=5:**
-- Start checking from i=3 (Rₜ+1=3)
-- Check D_{t-3}, D_{t-4}, D_{t-5}, ...
-- If all empty, Cₜ increases accordingly
-
-**Common mistake:** Starting from i=2 regardless of Rₜ. This works for R=1 but fails for R=2.
-
-### 4. Packet Indexing: 0-Based vs 1-Based in Flag Calculations
-
-The CCSDS reference implementation uses **1-based packet numbering** (packets 1, 2, 3...). If your implementation uses **0-based loop indexing** (i=0, 1, 2...), you MUST convert to 1-based when calculating flag triggers.
-
-**The Reference Uses 1-Based Packet Numbers:**
-- Packet 1 = first packet (our i=0)
-- Packet 11 = eleventh packet (our i=10) ← first ṗₜ trigger for Rₜ=1
-- Packet 21 = twenty-first packet (our i=20) ← first ḟₜ trigger for Rₜ=1
-
-**Example for Rₜ=1, pt_period=10:**
-
-| Loop Index (i) | Packet Number | Expected ṗₜ | Wrong (using i) | Impact |
-|----------------|---------------|-------------|-----------------|---------|
-| i=10 | Packet 11 | **1** (trigger!) | 0 | Flag missed! |
-| i=20 | Packet 21 | **1** (trigger!) | 0 | Flag missed! |
-| i=30 | Packet 31 | **1** (trigger!) | 0 | Flag missed! |
-
-**The Fix:** Use `packet_num = i + 1` when calculating flag triggers.
-- For i=10: packet_num=11, check if `11 % 10 == 1` ✓ Triggers correctly!
-- For i=20: packet_num=21, check if `21 % 10 == 1` ✓ Triggers correctly!
-
-**Common mistake:** Using loop index `i` directly for modulo arithmetic when flag triggers are defined in 1-based terms.
-
-**Why this matters:**
-- Wrong flags corrupt the dₜ calculation (flag_no_mask_updates_in_Xt)
-- Wrong ṗₜ causes mask/build updates at incorrect times
-- Wrong ḟₜ omits required mask transmission
-- Wrong ṙₜ sends compressed data when uncompressed is expected
-- **Result:** Complete divergence within 20-30 packets
-
-### 5. Component kₜ: Inverted Mask Values (Not Direct Mask Values!)
-
-The kₜ component encodes mask values at changed positions, but **outputs the INVERSE** of the mask bits.
-
-**CCSDS spec defines (Equations 19–20):** kₜ = yₜ = BE(<~Mₜ>, Xₜ) — the inversion (`~Mₜ`) is explicit in the formula, even though the Section 5.1 overview prose just calls it "information on the mask values for each change".
-**In practice:** Output '1' for positive updates (mask changed to 0), '0' for negative updates (mask changed to 1)
-
-**Correct encoding:**
-- When Xₜ has '1' at position i (bit changed):
-  - If mask[i] = 0 (now predictable): output **1** in kₜ
-  - If mask[i] = 1 (now unpredictable): output **0** in kₜ
-- This is the **INVERSE** of the mask values
-
-**Example:**
-- Xₜ = '1' at positions [43, 142]
-- Mask values at those positions: [0, 0] (both predictable)
-- kₜ output (extracted in forward order, low to high position): **11** (not 00!)
-
-**Why this matters:**
-- The eₜ flag indicates if there are "positive updates" (mask bits changed from 1→0, becoming predictable)
-- kₜ outputs '1' to mark these positive updates
-- Extracting mask values directly gives the opposite encoding
-- **Result:** 2-bit error per changed position, causing divergence at byte ~30% into output
-
-**Implementation:**
-```
-inverted_mask[i] = !mask[i]  // Invert the entire mask
-kt = BE(inverted_mask, Xt)   // Extract inverted values at changed positions
-```
-
-### Summary
-
-See [GOTCHAS.md](GOTCHAS.md) for the complete list of implementation pitfalls.
+These are documented in full — with worked examples, correct code, and impact analysis — in **[GOTCHAS.md](GOTCHAS.md)**. Read it before implementing. This section is intentionally a pointer rather than a copy, so the two documents cannot drift.
 
 ## High-Level Data Flow
 
@@ -224,7 +113,7 @@ Dₜ = Mₜ XOR Mₜ₋₁
 
 Initial condition: the spec (Equation 8) defines **D₀ = 0** directly (the XOR case applies only for t > 0). A convenient implementation strategy is to set M₋₁ = M₀ before the first packet so the XOR yields 0 without a special case.
 
-⚠️ **See [GOTCHAS.md #19](GOTCHAS.md#19-d₀-must-be-zero-at-initialization-not-m₀)** — A common mistake is treating the initial mask as a "change" (D₀ = M₀), which is wrong.
+⚠️ **See [GOTCHAS.md #18](GOTCHAS.md#18-d₀-must-be-zero-at-initialization-not-m₀)** — A common mistake is treating the initial mask as a "change" (D₀ = M₀), which is wrong.
 
 **Flow Diagram:**
 ```
@@ -266,7 +155,7 @@ Where:
 
 - **Vₜ**: Effective robustness level (4 bits, value 0-15)
 - **eₜ**: '1' if any changed position became predictable (a "positive update": mask bit now 0), '0' if all changes became unpredictable
-- **kₜ**: Inverted mask values at changed positions, kₜ = BE(<~Mₜ>, Xₜ) — see Critical Implementation Note #5
+- **kₜ**: Inverted mask values at changed positions, kₜ = BE(<~Mₜ>, Xₜ) — see [GOTCHAS.md #5](GOTCHAS.md#5--component-kₜ-forward-extraction-order-not-reverse)
 - **cₜ**: '1' if the new_mask_flag (ṗ) was set more than once in {max(0, t−Vₜ), …, t} (the current packet plus the previous Vₜ cycles)
 - **ḋₜ**: Flag indicating if both ḟₜ and ṙₜ are zero
 
@@ -376,16 +265,16 @@ BE(a, b) = a₆ ∥ a₄ ∥ a₁ = '100' (highest position extracted first)
 
 **Special Constraints:**
 - For the **first Rₜ+1 packets** (t ≤ Rₜ), the spec (3.3.2 c–d) mandates ḟₜ = 1 and ṙₜ = 1 (full mask and full input during initialization); the reference implementation additionally uses ṗₜ = 0
-  - ⚠️ **See [Critical Implementation Note #1](#1-initialization-phase-first-rₜ1-packets-not-rₜ2)** - Common off-by-one error!
+  - ⚠️ **See [GOTCHAS.md #1](GOTCHAS.md#1-initialization-phase-first-rₜ1-packets-not-rₜ2)** - Common off-by-one error!
 - In the reference implementation and shared test vectors, the timing of the ṗₜ, ḟₜ, ṙₜ flags is driven by period counters that start during initialization (the spec itself leaves the flags user-specified per packet)
-  - ⚠️ **See [Critical Implementation Note #2](#2-flag-timing-countdown-counters-not-modulo-arithmetic)** - Flags don't trigger when you expect!
+  - ⚠️ **See [GOTCHAS.md #2](GOTCHAS.md#2-flag-timing-countdown-counters-not-modulo-arithmetic)** - Flags don't trigger when you expect!
 - All parameters needed for decompression are encoded in the output bitstream
 
 ## Bit Numbering Convention
 
 ⚠️ **CRITICAL**: the **MSB is transmitted first**. What matters for interoperability is the *transmission order*; be careful not to confuse the standard's bit *labels* with the index convention used in this documentation and the implementations.
 
-**The standard's labeling (CCSDS 124.0-B-1 Section 1.6.3):** bits are numbered N−1 down to 0, with **bit N−1 = MSB = first transmitted**:
+**The standard's labeling (CCSDS 124.0-B-1 Section 1.6.1):** bits are numbered N−1 down to 0, with **bit N−1 = MSB = first transmitted**:
 ```
 ┌─────┬─────┬─────┬───┬───┬───┐
 │ N-1 │ N-2 │ N-3 │ … │ 1 │ 0 │  ← Bit labels in the standard
@@ -447,7 +336,7 @@ Vₜ = Rₜ + Cₜ
 - **Rₜ**: User-specified minimum required robustness level (0-7)
 - **Cₜ**: Additional robustness from consecutive unchanged masks
 
-**Important:** ⚠️ **See [Critical Implementation Note #3](#3-vₜ-calculation-start-from-rₜ1)** for common pitfalls!
+**Important:** ⚠️ **See [GOTCHAS.md #3](GOTCHAS.md#3-vₜ-calculation-start-from-rₜ1-not-position-2)** for common pitfalls!
 
 Per CCSDS 124.0-B-1 Section 5.3.2.2 (Equation 14), Cₜ is defined as:
 

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -19,31 +19,30 @@ Each gotcha includes:
 1. [Initialization Phase: First Rₜ+1 Packets (Not Rₜ+2!)](#1-initialization-phase-first-rₜ1-packets-not-rₜ2)
 2. [Flag Timing: Countdown Counters, Not Modulo Arithmetic](#2-flag-timing-countdown-counters-not-modulo-arithmetic)
 3. [Vₜ Calculation: Start from Rₜ+1, Not Position 2!](#3-vₜ-calculation-start-from-rₜ1-not-position-2)
-4. [Packet Indexing: 0-Based vs 1-Based in Flag Calculations](#4-packet-indexing-0-based-vs-1-based-in-flag-calculations)
-5. [Component kₜ: Inverted Mask Values (Not Direct Mask Values!)](#5-component-kₜ-inverted-mask-values-not-direct-mask-values)
-6. [Component kₜ: Forward Extraction Order (Not Reverse!)](#6--component-kₜ-forward-extraction-order-not-reverse)
-7. [Reference Implementation's Final Padding (FIXED)](#-gotcha-7-reference-implementations-final-padding-fixed)
-8. [cₜ Calculation: Include Current Packet's pₜ Flag!](#8-cₜ-calculation-include-current-packets-pₜ-flag)
-19. [D₀ Must Be Zero at Initialization (Not M₀!)](#19-d₀-must-be-zero-at-initialization-not-m₀)
-20. [Bitvector NOT: MSB-Aligned Masking for Non-Byte-Aligned Lengths](#20-bitvector-not-msb-aligned-masking-for-non-byte-aligned-lengths)
+4. [Component kₜ: Inverted Mask Values (Not Direct Mask Values!)](#4-component-kₜ-inverted-mask-values-not-direct-mask-values)
+5. [Component kₜ: Forward Extraction Order (Not Reverse!)](#5--component-kₜ-forward-extraction-order-not-reverse)
+6. [Reference Implementation's Final Padding (FIXED)](#-gotcha-6-reference-implementations-final-padding-fixed)
+7. [cₜ Calculation: Include Current Packet's pₜ Flag!](#7-cₜ-calculation-include-current-packets-pₜ-flag)
+18. [D₀ Must Be Zero at Initialization (Not M₀!)](#18-d₀-must-be-zero-at-initialization-not-m₀)
+19. [Bitvector NOT: MSB-Aligned Masking for Non-Byte-Aligned Lengths](#19-bitvector-not-msb-aligned-masking-for-non-byte-aligned-lengths)
 
 ### High-Level API Gotchas
 
-17. [Packet Byte-Boundary Padding](#17-packet-byte-boundary-padding)
-18. [COUNT Extended Format ('111'): Include Terminating '1' in Value](#18-count-extended-format-111-include-terminating-1-in-value)
+16. [Packet Byte-Boundary Padding](#16-packet-byte-boundary-padding)
+17. [COUNT Extended Format ('111'): Include Terminating '1' in Value](#17-count-extended-format-111-include-terminating-1-in-value)
 
 ### Decompression Gotchas
 
-9. [COUNT Decoding: '10' is Terminator, Not a Value](#9-count-decoding-10-is-terminator-not-a-value)
-10. [kₜ Reading Order: Forward (Low to High Position)](#10-kₜ-reading-order-forward-low-to-high-position)
-11. [kₜ Bit Interpretation: Inverted Mask Values](#11-kₜ-bit-interpretation-inverted-mask-values)
-12. [Unpredictable Bits: Insert in Reverse Order (BE)](#12-unpredictable-bits-insert-in-reverse-order-be)
-13. [Horizontal XOR Mask Decoding](#13-horizontal-xor-mask-decoding)
-14. [ḋₜ Flag Optimization](#14-ḋₜ-flag-optimization)
-15. [Vₜ=0 Special Case: Toggle Mask Bits](#15-vₜ0-special-case-toggle-mask-bits)
-16. [Extraction Mask: cₜ Affects Which Bits to Read](#16-extraction-mask-cₜ-affects-which-bits-to-read)
-21. [Decoder Must Validate Bitstream Integrity to Reject Corrupt Packets](#21-decoder-must-validate-bitstream-integrity-to-reject-corrupt-packets)
-22. [Decoder Cross-Validation: Mask Synchronization and Accuracy Guarantees](#22-decoder-cross-validation-mask-synchronization-and-accuracy-guarantees)
+8. [COUNT Decoding: '10' is Terminator, Not a Value](#8-count-decoding-10-is-terminator-not-a-value)
+9. [kₜ Reading Order: Forward (Low to High Position)](#9-kₜ-reading-order-forward-low-to-high-position)
+10. [kₜ Bit Interpretation: Inverted Mask Values](#10-kₜ-bit-interpretation-inverted-mask-values)
+11. [Unpredictable Bits: Insert in Reverse Order (BE)](#11-unpredictable-bits-insert-in-reverse-order-be)
+12. [Horizontal XOR Mask Decoding](#12-horizontal-xor-mask-decoding)
+13. [ḋₜ Flag Optimization](#13-ḋₜ-flag-optimization)
+14. [Vₜ=0 Special Case: Toggle Mask Bits](#14-vₜ0-special-case-toggle-mask-bits)
+15. [Extraction Mask: cₜ Affects Which Bits to Read](#15-extraction-mask-cₜ-affects-which-bits-to-read)
+20. [Decoder Must Validate Bitstream Integrity to Reject Corrupt Packets](#20-decoder-must-validate-bitstream-integrity-to-reject-corrupt-packets)
+21. [Decoder Cross-Validation: Mask Synchronization and Accuracy Guarantees](#21-decoder-cross-validation-mask-synchronization-and-accuracy-guarantees)
 
 ---
 
@@ -108,17 +107,21 @@ This triggers **one packet too early**:
 - ḟₜ=1 (send mask) at packets: **21, 41, 61, 81...** ✅ CORRECT
 - ṙₜ=1 (uncompressed) at packets: **51, 101, 151, 201...** ✅ CORRECT
 
-**Key insight:** First trigger happens at `period + Rₜ`, not at `period`.
+**Key insight:** The first trigger lands at `period + 1`, not `period`: the very first packet is the initialization packet and is emitted before the period counters start counting, so each counter completes its first full cycle one packet later. (For Rₜ=1 this happens to equal `period + Rₜ`, but the offset is always +1, regardless of Rₜ.)
 
-**Example for pt_period=10, Rₜ=1:**
+**Example for pt_period=10** (countdown counter, matching the title — not modulo):
 ```c
-int pt_first_trigger = pt_period + Rt;  // 10 + 1 = 11
-int packet_num = i + 1;  // Convert 0-based to 1-based
-
-if (packet_num >= pt_first_trigger &&
-    packet_num % pt_period == (pt_first_trigger % pt_period)) {
-    pt_flag = 1;  // Triggers at packets 11, 21, 31, ...
+// Counters start at the period limit. The first (init) packet is emitted
+// before counting begins; from the next packet onward, decrement and fire
+// when the counter reaches 1, then reload:
+if (pt_counter == 1) {
+    pt_flag = 1;
+    pt_counter = pt_period;   // reload
+} else {
+    pt_flag = 0;
+    pt_counter--;
 }
+// For pt_period = 10 this fires at packets 11, 21, 31, ...
 ```
 
 ### 📊 Impact
@@ -190,61 +193,7 @@ Vt = Rt + Ct;
 
 ---
 
-## 4. Packet Indexing: 0-Based vs 1-Based in Flag Calculations
-
-### ✅ What the Spec Says
-
-The CCSDS reference implementation uses **1-based packet numbering** (packets 1, 2, 3...).
-
-### ❌ Common Mistake
-
-Using loop index `i` directly for flag calculations when implementing with 0-based indexing:
-
-```c
-// WRONG: Uses 0-based index directly
-for (int i = 0; i < num_packets; i++) {
-    if (i % pt_period == 0) {  // ❌ Triggers at i=10, 20, 30...
-        pt_flag = 1;
-    }
-}
-```
-
-**Impact table:**
-
-| Loop Index (i) | Packet Number | Expected ṗₜ | Wrong (using i) | Impact |
-|----------------|---------------|-------------|-----------------|---------|
-| i=10 | Packet 11 | **1** (trigger!) | 0 | Flag missed! |
-| i=20 | Packet 21 | **1** (trigger!) | 0 | Flag missed! |
-| i=30 | Packet 31 | **1** (trigger!) | 0 | Flag missed! |
-
-### 🔧 Correct Implementation
-
-```c
-// CORRECT: Convert to 1-based packet numbering
-for (int i = 0; i < num_packets; i++) {
-    int packet_num = i + 1;  // 0-based → 1-based conversion
-
-    if (packet_num >= pt_first_trigger &&
-        packet_num % pt_period == (pt_first_trigger % pt_period)) {
-        pt_flag = 1;  // ✅ Correctly triggers at packets 11, 21, 31...
-    }
-}
-```
-
-### 📊 Impact
-
-- **Divergence:** Byte 200-300 (30-50% into stream)
-- **Symptom:** Wrong flags cause complete corruption
-- **Size error:** 20-30% size difference
-- **Why this matters:**
-  - Wrong flags corrupt the dₜ calculation
-  - Wrong ṗₜ causes mask/build updates at incorrect times
-  - Wrong ḟₜ omits required mask transmission
-  - Wrong ṙₜ sends compressed data when uncompressed is expected
-
----
-
-## 5. Component kₜ: Inverted Mask Values (Not Direct Mask Values!)
+## 4. Component kₜ: Inverted Mask Values (Not Direct Mask Values!)
 
 ### ✅ What the Spec Says
 
@@ -296,7 +245,7 @@ kt = BE(inverted_mask, Xt);  // Extract inverted values at changed positions
 
 ---
 
-## 6. ⭐ Component kₜ: Forward Extraction Order (Not Reverse!)
+## 5. ⭐ Component kₜ: Forward Extraction Order (Not Reverse!)
 
 **⭐ Latest Discovery - December 2025**
 
@@ -432,12 +381,12 @@ The reference implementation has different code paths for these operations, and 
    - Should match perfectly if #1-3 are correct
 
 2. **Packets 10-12:** Check flag values
-   - Tests: Flag timing, packet indexing
+   - Tests: Flag timing
    - Print pt, ft, rt for each packet
 
 3. **Packets 20-30:** Check for divergence
    - Tests: All flag-related issues
-   - Should match if #1-4 are correct
+   - Should match if #1-3 are correct
 
 4. **Packets 30-50:** Check kₜ component
    - Tests: kₜ inversion and extraction order
@@ -487,7 +436,7 @@ Packet 2: Vt=2 (Rt + Ct, where Ct=1 from D0=0)
 Packet 3+: Varies based on mask changes
 ```
 
-**Note:** D₀ is always 0 (see [Gotcha #19](#19-d₀-must-be-zero-at-initialization-not-m₀)). At t=0 the caller sets M₋₁ = M₀, so D₀ = M₀ XOR M₀ = 0 regardless of M₀'s value.
+**Note:** D₀ is always 0 (see [Gotcha #18](#18-d₀-must-be-zero-at-initialization-not-m₀)). At t=0 the caller sets M₋₁ = M₀, so D₀ = M₀ XOR M₀ = 0 regardless of M₀'s value.
 
 ---
 
@@ -523,15 +472,14 @@ Before declaring your implementation "working":
 | Divergence at byte 30-50 | Flag timing wrong (#2) | Check countdown logic |
 | Divergence at byte 5-15 | Vₜ wrong (#3) | Start from Rₜ+1, not i=2 |
 | Byte mismatch in R=2 tests | Vₜ start position wrong (#3) | Use i=Rₜ+1 not i=2 |
-| Divergence at byte 200-300 | Packet indexing wrong (#4) | Convert i to packet_num |
-| 1-bit errors in kₜ | kₜ not inverted (#5) | Invert mask before extraction |
-| 2-bit shift at byte 300+ | kₜ extraction order wrong (#6) | Use forward order for kₜ |
-| Size off by 10%+ | Multiple flag issues | Check #2 and #4 |
-| Size matches but content wrong | Bit-level issues | Check #5 and #6 |
-| Size off by ~100 bytes (10KB test) | cₜ missing current flag (#8) | Include current pₜ in cₜ count |
-| edge-cases fails, simple passes | cₜ calculation wrong (#8) | Check Vₜ+1 entries for cₜ |
-| First 2 bits `11...` not `10` with non-zero M₀ | D₀ = M₀ instead of 0 (#19) | Set prev_mask = mask before t=0 |
-| Extra 1-bits in non-byte-aligned vectors | NOT masks low bits not high (#20) | Use MSB-aligned byte mask in NOT |
+| 1-bit errors in kₜ | kₜ not inverted (#4) | Invert mask before extraction |
+| 2-bit shift at byte 300+ | kₜ extraction order wrong (#5) | Use forward order for kₜ |
+| Size off by 10%+ | Multiple flag issues | Check #1 and #2 |
+| Size matches but content wrong | Bit-level issues | Check #4 and #5 |
+| Size off by ~100 bytes (10KB test) | cₜ missing current flag (#7) | Include current pₜ in cₜ count |
+| edge-cases fails, simple passes | cₜ calculation wrong (#7) | Check Vₜ+1 entries for cₜ |
+| First 2 bits `11...` not `10` with non-zero M₀ | D₀ = M₀ instead of 0 (#18) | Set prev_mask = mask before t=0 |
+| Extra 1-bits in non-byte-aligned vectors | NOT masks low bits not high (#19) | Use MSB-aligned byte mask in NOT |
 
 ---
 
@@ -559,7 +507,7 @@ Each of these seemingly minor differences will cause your implementation to fail
 
 ---
 
-## 🎯 Gotcha #7: Reference Implementation's Final Padding (FIXED)
+## 🎯 Gotcha #6: Reference Implementation's Final Padding (FIXED)
 
 ### ✅ Status: FIXED
 
@@ -596,7 +544,7 @@ See [../test-vector-generator/c-reference/CHANGES.md](../test-vector-generator/c
 
 ---
 
-## 8. cₜ Calculation: Include Current Packet's pₜ Flag!
+## 7. cₜ Calculation: Include Current Packet's pₜ Flag!
 
 **⭐ Discovery - December 2025**
 
@@ -681,7 +629,7 @@ The following gotchas are specific to implementing the decompressor.
 
 ---
 
-## 9. COUNT Decoding: '10' is Terminator, Not a Value
+## 8. COUNT Decoding: '10' is Terminator, Not a Value
 
 ### ✅ What the Spec Says
 
@@ -721,7 +669,7 @@ if (bit0 == 0) {
 
 ---
 
-## 10. kₜ Reading Order: Forward (Low to High Position)
+## 9. kₜ Reading Order: Forward (Low to High Position)
 
 ### ✅ What Happens During Compression
 
@@ -757,7 +705,7 @@ for (size_t i = 0; i < F; i++) {
 
 ---
 
-## 11. kₜ Bit Interpretation: Inverted Mask Values
+## 10. kₜ Bit Interpretation: Inverted Mask Values
 
 ### ✅ What the Encoder Outputs
 
@@ -793,7 +741,7 @@ if (kt_bits[kt_idx] == 1) {
 
 ---
 
-## 12. Unpredictable Bits: Insert in Reverse Order (BE)
+## 11. Unpredictable Bits: Insert in Reverse Order (BE)
 
 ### ✅ What the Encoder Does
 
@@ -831,7 +779,7 @@ for (size_t i = count; i > 0; i--) {
 
 ---
 
-## 13. Horizontal XOR Mask Decoding
+## 12. Horizontal XOR Mask Decoding
 
 ### ✅ What the Encoder Sends
 
@@ -874,7 +822,7 @@ for (size_t i = F - 1; i > 0; i--) {
 
 ---
 
-## 14. ḋₜ Flag Optimization
+## 13. ḋₜ Flag Optimization
 
 ### ✅ What the Spec Says (Equation 13)
 
@@ -914,7 +862,7 @@ if (dt == 0) {
 
 ---
 
-## 15. Vₜ=0 Special Case: Toggle Mask Bits
+## 14. Vₜ=0 Special Case: Toggle Mask Bits
 
 ### ✅ What Happens
 
@@ -957,7 +905,7 @@ if (Vt > 0 && change_count > 0) {
 
 ---
 
-## 16. Extraction Mask: cₜ Affects Which Bits to Read
+## 15. Extraction Mask: cₜ Affects Which Bits to Read
 
 ### ✅ What the Spec Says
 
@@ -1023,7 +971,7 @@ Before declaring your decompressor "working":
 
 ---
 
-## 17. Packet Byte-Boundary Padding
+## 16. Packet Byte-Boundary Padding
 
 **⭐ Discovery - December 2025**
 
@@ -1088,7 +1036,7 @@ return output.toByteArray();
 
 ---
 
-## 18. COUNT Extended Format ('111'): Include Terminating '1' in Value
+## 17. COUNT Extended Format ('111'): Include Terminating '1' in Value
 
 **⭐ Discovery - December 2025**
 
@@ -1175,7 +1123,7 @@ return value + 2;
 
 ---
 
-## 19. D₀ Must Be Zero at Initialization (Not M₀!)
+## 18. D₀ Must Be Zero at Initialization (Not M₀!)
 
 **⭐ Discovery - February 2026 (CCSDS Cross-Validation)**
 
@@ -1238,7 +1186,7 @@ bitvector_xor(change, mask, prev_mask);  // D₀ = M₀ XOR M₀ = 0
 
 ---
 
-## 20. Bitvector NOT: MSB-Aligned Masking for Non-Byte-Aligned Lengths
+## 19. Bitvector NOT: MSB-Aligned Masking for Non-Byte-Aligned Lengths
 
 **⭐ Discovery - February 2026 (CCSDS Cross-Validation)**
 
@@ -1292,7 +1240,7 @@ result_byte = (~input_byte) & byte_mask;
 
 ---
 
-## 21. Decoder Must Validate Bitstream Integrity to Reject Corrupt Packets
+## 20. Decoder Must Validate Bitstream Integrity to Reject Corrupt Packets
 
 **Category:** Decompression
 **Discovery:** CCSDS cross-validation (decoder vectors include intentionally corrupt/fuzzed packets)
@@ -1339,7 +1287,7 @@ bitvector_set_bit(result, bit_position, 1);
 
 ---
 
-## 22. Decoder Cross-Validation: Mask Synchronization and Accuracy Guarantees
+## 21. Decoder Cross-Validation: Mask Synchronization and Accuracy Guarantees
 
 **Category:** Decompression
 **Discovery:** CCSDS cross-validation (decoder vectors with unknown initial mask and fuzzed packets)

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -2,7 +2,7 @@
 
 ## Before You Start
 
-**Read [GOTCHAS.md](GOTCHAS.md) first!** It documents 22 critical pitfalls that will cause your implementation to fail silently.
+**Read [GOTCHAS.md](GOTCHAS.md) first!** It documents 21 critical pitfalls that will cause your implementation to fail silently.
 
 ## Validation Requirements
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -269,7 +269,7 @@ make crossvalidation \
 
 **Total**: 23,037 of 24,900 cross-validation vectors passed
 
-The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #19, #20, #21, and #22).
+The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #18, #19, #20, and #21).
 
 ### Reverse-Engineered Validation Rules
 
@@ -293,11 +293,11 @@ Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees 
 
 **16 vectors — unknown excess-rejection rule**: the reference rejects certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
 
-**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #22.
+**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #21.
 
 Other known gaps:
 - Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
-- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #21) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #20) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
 
 ## Run All Tests
 

--- a/implementations/c/CHANGELOG.md
+++ b/implementations/c/CHANGELOG.md
@@ -15,6 +15,6 @@ Releases are tagged `c/vX.Y.Z`.
 - CLI tool for compress/decompress operations
 - `ccsds124_decompress_packet_checked()` — single-packet decompression with accuracy guarantee tracking (mask synchronization, status history, state save/restore, guarantee decision tree)
 - `ccsds124_discover_packet_length()` — discover F from a compressed packet bitstream, with signaled-length validity rules (range 1–65535, RLE span consistency) and truncated-reference signaling via `CCSDS124_STATUS_TRUNCATED_LENGTH`
-- Bitstream integrity validation in the decoder: underflow detection, RLE delta bounds checking, post-decompression padding verification (GOTCHAS.md #21)
+- Bitstream integrity validation in the decoder: underflow detection, RLE delta bounds checking, post-decompression padding verification (GOTCHAS.md #20)
 - Reference packets (`rt=1`) tolerate excess trailing bits in checked decompression (self-delimiting via `COUNT(F)`); compressed packets (`rt=0`) keep the strict ≤7-padding-bits rule
 - MISRA-C:2012 compliance, fuzzing harnesses, and CCSDS cross-validation harness (UAB suite)

--- a/implementations/cpp/include/ccsds124/decoder.hpp
+++ b/implementations/cpp/include/ccsds124/decoder.hpp
@@ -143,7 +143,7 @@ template <std::size_t N> Error rle_decode(BitReader& reader, BitVector<N>& resul
     while (status == Error::Ok && delta != 0) {
         // Delta represents (count of zeros + 1). A delta beyond the
         // remaining bit position means the encoding is invalid for this
-        // vector length (GOTCHAS #21): reject it instead of silently
+        // vector length (GOTCHAS #20): reject it instead of silently
         // skipping.
         if (delta > bit_position) {
             return Error::Overflow;
@@ -180,7 +180,7 @@ Error bit_insert(BitReader& reader, BitVector<N>& data, const BitVector<N>& mask
         return Error::Ok;
     }
 
-    // GOTCHAS #21: fail on underflow instead of silently skipping positions
+    // GOTCHAS #20: fail on underflow instead of silently skipping positions
     if (reader.remaining() < hamming) {
         return Error::Underflow;
     }
@@ -225,7 +225,7 @@ Error bit_insert(BitReader& reader, BitVector<N>& data, const BitVector<N>& mask
  */
 template <std::size_t N>
 Error bit_insert_forward(BitReader& reader, BitVector<N>& data, const BitVector<N>& mask) noexcept {
-    // GOTCHAS #21: fail on underflow instead of silently skipping positions
+    // GOTCHAS #20: fail on underflow instead of silently skipping positions
     if (reader.remaining() < mask.hamming_weight()) {
         return Error::Underflow;
     }

--- a/implementations/cpp/tests/test_decoder.cpp
+++ b/implementations/cpp/tests/test_decoder.cpp
@@ -322,7 +322,7 @@ TEST_CASE("Bit insert with empty mask", "[decoder]") {
 }
 
 TEST_CASE("RLE decode rejects invalid delta", "[decoder][hardening]") {
-    // GOTCHAS #21 / issue #92: an RLE delta exceeding the remaining bit
+    // GOTCHAS #20 / issue #92: an RLE delta exceeding the remaining bit
     // position must be rejected, not silently skipped.
     // COUNT(9) = '110'+BIT5(7), then terminator '10' -> 0xC7 0x80.
     std::uint8_t data[] = {0xC7, 0x80};
@@ -334,7 +334,7 @@ TEST_CASE("RLE decode rejects invalid delta", "[decoder][hardening]") {
 }
 
 TEST_CASE("Bit insert rejects truncated input", "[decoder][hardening]") {
-    // GOTCHAS #21 / issue #92: bit_insert must fail on underflow instead of
+    // GOTCHAS #20 / issue #92: bit_insert must fail on underflow instead of
     // silently skipping positions. Mask needs 8 bits but only 3 available.
     std::uint8_t data[] = {0xE0};
     BitReader reader(data, 3);

--- a/implementations/cpp/tests/test_decompressor.cpp
+++ b/implementations/cpp/tests/test_decompressor.cpp
@@ -387,7 +387,7 @@ TEST_CASE("Compress/decompress round trip - alternating patterns", "[decompresso
 }
 
 TEST_CASE("Decompress rejects truncated packet", "[decompressor][hardening]") {
-    // GOTCHAS #21 / issue #92: a packet that ends mid-header must produce an
+    // GOTCHAS #20 / issue #92: a packet that ends mid-header must produce an
     // error, not silently decode garbage. Two bits: RLE terminator '10',
     // then the stream ends before BIT4(Vt).
     std::uint8_t data[] = {0x80};

--- a/implementations/go/ccsds124/decode.go
+++ b/implementations/go/ccsds124/decode.go
@@ -128,7 +128,7 @@ func RLEDecode(br *BitReader, length int) (*BitVector, error) {
 
 		// Move position back by count. A delta beyond the remaining bit
 		// position means the encoding is invalid for this vector length
-		// (GOTCHAS #21): reject it instead of silently skipping.
+		// (GOTCHAS #20): reject it instead of silently skipping.
 		if count > position {
 			return nil, fmt.Errorf("RLE decode: invalid delta %d exceeds remaining bit position %d", count, position)
 		}

--- a/implementations/go/ccsds124/decode_test.go
+++ b/implementations/go/ccsds124/decode_test.go
@@ -433,7 +433,7 @@ func TestBitInsertInsufficientBits(t *testing.T) {
 	}
 }
 
-// TestRLEDecodeRejectsInvalidDelta verifies GOTCHAS #21 / issue #92:
+// TestRLEDecodeRejectsInvalidDelta verifies GOTCHAS #20 / issue #92:
 // an RLE delta exceeding the remaining bit position must be rejected,
 // not silently skipped.
 func TestRLEDecodeRejectsInvalidDelta(t *testing.T) {

--- a/implementations/java/src/main/java/space/tanagra/ccsds124/BitVector.java
+++ b/implementations/java/src/main/java/space/tanagra/ccsds124/BitVector.java
@@ -193,7 +193,7 @@ public final class BitVector {
 
       // Create mask for valid bits in big-endian word.
       // MSB-first: valid bits in a partial last byte are at the HIGH end of
-      // the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
+      // the byte, so mask 0xFF << (8 - bits) (GOTCHAS #19).
       int mask = 0;
       for (int b = 0; b < bytesInLastWord; b++) {
         int byteMask;

--- a/implementations/java/src/main/java/space/tanagra/ccsds124/Decoder.java
+++ b/implementations/java/src/main/java/space/tanagra/ccsds124/Decoder.java
@@ -108,7 +108,7 @@ public final class Decoder {
 
     while (delta != 0) {
       // A delta beyond the remaining bit position means the encoding is
-      // invalid for this vector length (GOTCHAS #21): reject it instead of
+      // invalid for this vector length (GOTCHAS #20): reject it instead of
       // silently skipping.
       if (delta > bitPosition) {
         throw new Ccsds124Exception("Invalid RLE delta: exceeds remaining bit position");

--- a/implementations/java/src/main/javadoc/overview.html
+++ b/implementations/java/src/main/javadoc/overview.html
@@ -6,7 +6,7 @@
 <body>
 
 <p>Java implementation of the <a href="https://ccsds.org/Pubs/124x0b1.pdf">CCSDS 124.0-B-1</a>
-CCSDS 124.0-B-1 lossless compression algorithm for satellite housekeeping telemetry.</p>
+lossless compression algorithm for satellite housekeeping telemetry.</p>
 
 <h1>Citation</h1>
 

--- a/implementations/java/src/test/java/space/tanagra/ccsds124/BitVectorTest.java
+++ b/implementations/java/src/test/java/space/tanagra/ccsds124/BitVectorTest.java
@@ -110,7 +110,7 @@ class BitVectorTest {
     assertEquals(0, result.getBit(7));
   }
 
-  // GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set the
+  // GOTCHAS #19 (issue #103): NOT of a non-byte-aligned vector must set the
   // valid (high) bits and leave padding zero. NOT of an all-zero length-12
   // vector: positions 0..12 must all be 1.
   @Test

--- a/implementations/java/src/test/java/space/tanagra/ccsds124/EncoderDecoderTest.java
+++ b/implementations/java/src/test/java/space/tanagra/ccsds124/EncoderDecoderTest.java
@@ -200,7 +200,7 @@ class EncoderDecoderTest {
   }
 
   /**
-   * GOTCHAS #21 / issue #92: an RLE delta exceeding the remaining bit position must be rejected,
+   * GOTCHAS #20 / issue #92: an RLE delta exceeding the remaining bit position must be rejected,
    * not silently skipped.
    */
   @Test

--- a/implementations/java/src/test/java/space/tanagra/ccsds124/MaskOperationsTest.java
+++ b/implementations/java/src/test/java/space/tanagra/ccsds124/MaskOperationsTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class MaskOperationsTest {
 
   /**
-   * Regression test for GOTCHAS #19 (issue #98): CCSDS Eq. 8 defines D0 = 0 regardless of the
+   * Regression test for GOTCHAS #18 (issue #98): CCSDS Eq. 8 defines D0 = 0 regardless of the
    * initial mask M0 — there is no change to communicate at initialization. The pre-fix behavior (D0
    * = M0) wrongly encoded a non-zero initial mask as a change.
    */

--- a/implementations/python/ccsds124/bitvector.py
+++ b/implementations/python/ccsds124/bitvector.py
@@ -277,7 +277,7 @@ class BitVector:
 
             # Create mask for valid bits in big-endian word.
             # MSB-first: valid bits in a partial last byte are at the HIGH
-            # end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
+            # end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #19).
             mask = 0
             for byte in range(bytes_in_last_word):
                 if byte == bytes_in_last_word - 1:

--- a/implementations/python/ccsds124/decode.py
+++ b/implementations/python/ccsds124/decode.py
@@ -123,7 +123,7 @@ def rle_decode(reader: "BitReader", length: int) -> "BitVector":
 
         # Move position back by count. A delta beyond the remaining bit
         # position means the encoding is invalid for this vector length
-        # (GOTCHAS #21): reject it instead of silently skipping.
+        # (GOTCHAS #20): reject it instead of silently skipping.
         if count > position:
             raise ValueError("invalid RLE delta: exceeds remaining bit position")
         position -= count

--- a/implementations/python/tests/test_bitvector.py
+++ b/implementations/python/tests/test_bitvector.py
@@ -178,7 +178,7 @@ class TestBitVectorBitwiseOps:
             assert result.get_bit(i) == 0
 
     def test_not_msb_aligned_non_byte_aligned(self) -> None:
-        """GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set
+        """GOTCHAS #19 (issue #103): NOT of a non-byte-aligned vector must set
         the valid (high) bits and leave padding zero.
 
         NOT of an all-zero length-12 vector: positions 0..11 must all be 1.

--- a/implementations/python/tests/test_compress.py
+++ b/implementations/python/tests/test_compress.py
@@ -352,7 +352,7 @@ class TestEffectiveRobustnessCap:
 
 
 class TestNonZeroInitialMask:
-    """Regression tests for GOTCHAS #19: D0 = 0 per CCSDS Eq. 8 (issue #98)."""
+    """Regression tests for GOTCHAS #18: D0 = 0 per CCSDS Eq. 8 (issue #98)."""
 
     def test_first_packet_starts_with_rle_terminator(self) -> None:
         """With a non-zero M0, the first packet must still encode X0 = 0.

--- a/implementations/python/tests/test_decode.py
+++ b/implementations/python/tests/test_decode.py
@@ -313,7 +313,7 @@ class TestBitInsertForward:
 
 
 class TestRLEDeltaValidation:
-    """GOTCHAS #21 / issue #92: invalid RLE deltas must be rejected."""
+    """GOTCHAS #20 / issue #92: invalid RLE deltas must be rejected."""
 
     def test_rle_decode_rejects_delta_beyond_position(self) -> None:
         # COUNT(9) = '110'+BIT5(7), then terminator '10' -> 0xC7 0x80.

--- a/implementations/rust/src/bitvector.rs
+++ b/implementations/rust/src/bitvector.rs
@@ -283,7 +283,7 @@ impl BitVector {
 
             // Create mask for valid bits in big-endian word.
             // MSB-first: valid bits in a partial last byte are at the HIGH
-            // end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #20).
+            // end of the byte, so mask 0xFF << (8 - bits) (GOTCHAS #19).
             let mut mask = 0u32;
             for byte in 0..bytes_in_last_word {
                 let byte_mask: u8 = if byte == bytes_in_last_word - 1 {
@@ -483,7 +483,7 @@ mod tests {
         assert_eq!(result.get_bit(3), 1);
     }
 
-    // GOTCHAS #20 (issue #103): NOT of a non-byte-aligned vector must set the
+    // GOTCHAS #19 (issue #103): NOT of a non-byte-aligned vector must set the
     // valid (high) bits and leave padding zero. NOT of an all-zero length-12
     // vector: positions 0..12 must all be 1.
     #[test]

--- a/implementations/rust/src/decode.rs
+++ b/implementations/rust/src/decode.rs
@@ -95,7 +95,7 @@ pub fn rle_decode(reader: &mut BitReader, length: usize) -> Result<BitVector, Cc
     while delta != 0 {
         // Delta represents (count of zeros + 1). A delta beyond the
         // remaining bit position means the encoding is invalid for this
-        // vector length (GOTCHAS #21): reject it instead of silently
+        // vector length (GOTCHAS #20): reject it instead of silently
         // skipping.
         if (delta as usize) > bit_position {
             return Err(Ccsds124Error::InvalidFormat(
@@ -155,7 +155,7 @@ pub fn bit_insert(
 mod tests {
     use super::*;
 
-    /// GOTCHAS #21 / issue #92: an RLE delta exceeding the remaining bit
+    /// GOTCHAS #20 / issue #92: an RLE delta exceeding the remaining bit
     /// position must be rejected, not silently skipped.
     #[test]
     fn test_rle_decode_rejects_invalid_delta() {


### PR DESCRIPTION
A documentation correctness + consistency pass on `GOTCHAS.md` and `ALGORITHM.md`, plus the original #4 removal/renumber. Driven by an exhaustive multi-pass audit (independent reviewers per document + deterministic link/residue checks, iterated to convergence).

### 1. Remove redundant GOTCHA #4 + renumber 5–22 → 4–21
#4 duplicated #1 (init) and #2 (flag timing); its impact table was wrong (`10 % 10 == 0` is true, so the flag fires — it doesn't "miss"). Removed and renumbered everywhere: GOTCHAS headings/ToC/anchors/cross-refs/Common-Symptoms table/smoke-tests, `GUIDELINES.md` count (22→21), `TESTING.md` list (#19–22 → #18–21), and every `GOTCHA #N` comment/test across all six implementations + crossvalidation docs + C CHANGELOG. GitHub issue numbers untouched.

### 2. Correctness fixes (the class a spec-vs-code audit can't catch)
- **`period + Rₜ` → `period + 1`** — the first trigger offset comes from the init packet being emitted before the counters start; it only coincided with `period + Rₜ` at Rₜ=1 (the test-vector case), which is why it produced correct output and was never caught.
- GOTCHAS #2's example used **modulo**, contradicting its own "countdown, not modulo" title — replaced with the countdown-counter pattern.
- Corrected a wrong spec citation: bit-numbering is **§1.6.1**, not §1.6.3 (verified against the spec PDF — no §1.6.3 exists).
- Fixed a cross-line `CCSDS 124.0-B-1 CCSDS 124.0-B-1` duplication in the Java javadoc `overview.html`.

### 3. De-duplication + link integrity
`ALGORITHM.md` carried a "Critical Implementation Notes" section duplicating gotchas #1–#4 — with the **same** wrong packet-indexing table and `period + Rₜ` claim (the root cause this survived earlier spec-conformance audits: ALGORITHM.md was the oracle, never the subject, and the two copies agreed with each other). Collapsed it to a pointer to GOTCHAS.md, and repointed the in-doc links that referenced the removed sections to the matching GOTCHAS.md anchors.

### Verification (converged)
- Repo-wide markdown **link/anchor integrity check** across all 30 tracked docs passes.
- Quantitative worked examples (flag triggers, Reference Values table, Vₜ progression) recomputed and correct.
- Zero residue: no `#22` / `Gotcha 4` / `period + Rₜ` (except the explicit "+1, not +Rₜ" clarification) / duplicate-brand / `pocketplus` / dangling cross-refs.
- Documentation/comment only — all six implementations still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)