### PR TITLE
docs: add CONFORMANCE.md, surface conformance in README, rename GUIDELINES → Porting & Build Notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,10 @@ python: fix decompression bug
 
 ## Important Files to Check
 
-- `docs/GOTCHAS.md` - Critical implementation pitfalls (read first!)
-- `docs/GUIDELINES.md` - Implementation quick start
+- `docs/GOTCHAS.md` - Implementer's Guide: byte-level pitfalls (read first!)
 - `docs/ALGORITHM.md` - Algorithm specification
+- `docs/CONFORMANCE.md` - Conformance evidence and cross-validation results
+- `docs/GUIDELINES.md` - Porting & build notes (per-language build/test/style)
 - `test-vectors/README.md` - Test data format and usage
 - Each implementation's `README.md` and `CHANGELOG.md`
 
@@ -159,7 +160,7 @@ make crossvalidation
 
 The runner script writes a results file (defaults to `build/crossvalidation-results.txt` when invoked via `make`). Override via `RESULTS_FILE` env var. The file contains a header (date, binaries, mode), per-phase pass/fail counts, failure details, and a final PASS/FAIL verdict.
 
-The verdict honors the known-failures baseline (`crossvalidation/known-failures.txt`): failures that match the baseline exactly produce **PASS (matches known-failures baseline)**; only regressions or new failures produce **FAIL**. The baseline entries are documented gaps in the decoder accuracy guarantee logic (see `docs/TESTING.md` Known Gaps).
+The verdict honors the known-failures baseline (`crossvalidation/known-failures.txt`): failures that match the baseline exactly produce **PASS (matches known-failures baseline)**; only regressions or new failures produce **FAIL**. The baseline entries are documented gaps in the decoder accuracy guarantee logic (see `docs/CONFORMANCE.md` Known Gaps).
 
 ### Environment Variables
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git push origin python/v1.0.0
 ## Documentation
 
 - [Algorithm Specification](docs/ALGORITHM.md) - CCSDS 124.0-B-1 algorithm details
-- [Implementation Guidelines](docs/GUIDELINES.md) - Quick start for implementers
+- [Porting & Build Notes](docs/GUIDELINES.md) - per-language build, test, and style notes
 - [Common Gotchas](docs/GOTCHAS.md) - Critical pitfalls to avoid
 - [Test Vectors](test-vectors/README.md) - Validation test data
 
@@ -63,7 +63,7 @@ All implementations are designed to be interoperable:
 
 Contributions are welcome! Please:
 
-1. Read the [Implementation Guide](docs/GUIDELINES.md)
+1. Read the [Porting & Build Notes](docs/GUIDELINES.md)
 2. Ensure your changes pass all test vectors
 3. Update relevant CHANGELOG.md
 4. Follow language-specific conventions

--- a/README.md
+++ b/README.md
@@ -32,12 +32,17 @@ POCKET+ is an European Space Agency (ESA) patented lossless compression algorith
 
 The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compressing fixed-length spacecraft housekeeping packets.
 
+## Conformance
+
+Conforms to **CCSDS 124.0-B-1** (Blue Book, February 2023), demonstrated two ways: **byte-identical output to the ESA reference implementation** on all shared reference vectors, and validation against the **UAB/CNES cross-validation suite** — the standard's own 24,900-vector test bench. Full results, the standard issue conformed to, per-implementation status, and documented gaps are in **[CONFORMANCE.md](docs/CONFORMANCE.md)**.
+
 ## Documentation
 
 - 📘 **[Implementer's Guide](docs/GOTCHAS.md)** — if you are implementing CCSDS 124.0-B-1 yourself, start here. It documents the 21 byte-level pitfalls (each tagged as spec-mandated or a reference-conformance detail, with section/equation citations) that you must get right to produce byte-identical output.
 - **[Algorithm Reference](docs/ALGORITHM.md)** — the encoding/decoding steps, equations, and worked examples.
-- **[Conformance & Testing](docs/TESTING.md)** — test vectors, cross-validation results, and documented gaps.
-- **[Implementation Guidelines](docs/GUIDELINES.md)** — per-language build, test, and style notes.
+- **[Conformance](docs/CONFORMANCE.md)** — what the project conforms to and the evidence: byte-identical-to-reference plus the UAB/CNES cross-validation results and documented gaps.
+- **[Test Report](docs/TESTING.md)** — the engineering test suite: unit, malformed-input, robustness, packet-loss, fuzzing, and reference-vector tests.
+- **[Porting & Build Notes](docs/GUIDELINES.md)** — per-language build, test, and style notes.
 
 ## Implementations
 
@@ -51,7 +56,7 @@ The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compress
 | Java | 1.0.0 | Yes | No | Embedded Linux / Desktop / Server | [`implementations/java/`](implementations/java/) |
 
 ¹ Byte-for-byte validated against the ESA reference implementation via the shared [test vectors](test-vectors/).
-² Validated against the UAB CCSDS 124.0-B-1 cross-validation suite (24,900 vectors): encoder 100%, decoder 89% with [documented gaps](docs/TESTING.md#known-gaps-1863-decoder-vectors) in the accuracy guarantee logic for fuzzed packets. Harnesses for the other implementations are tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93).
+² Validated against the UAB/CNES CCSDS 124.0-B-1 cross-validation suite (24,900 vectors); see [CONFORMANCE.md](docs/CONFORMANCE.md) for results and documented gaps. Harnesses for the other implementations are tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93).
 
 ### Which implementation should I use?
 

--- a/crossvalidation/README.md
+++ b/crossvalidation/README.md
@@ -67,7 +67,7 @@ ENCODER_BIN=./build/encoder DECODER_BIN=./build/decoder bash crossvalidation/run
 
 ## Known-Failures Baseline
 
-The C decoder has **1,863 documented gaps** in the accuracy guarantee accept/reject logic (see [docs/TESTING.md](../docs/TESTING.md#known-gaps-1863-decoder-vectors) for the full analysis). These vector names are recorded in `known-failures.txt`. The runner's verdict is:
+The C decoder has **1,863 documented gaps** in the accuracy guarantee accept/reject logic (see [docs/CONFORMANCE.md](../docs/CONFORMANCE.md#known-gaps-1863-decoder-vectors) for the full analysis). These vector names are recorded in `known-failures.txt`. The runner's verdict is:
 
 - **PASS** — zero failures
 - **PASS (matches known-failures baseline)** — every failure is listed in the baseline; any baseline entries that now pass are reported so the file can be trimmed

--- a/crossvalidation/known-failures.txt
+++ b/crossvalidation/known-failures.txt
@@ -1,6 +1,6 @@
 # CCSDS 124.0-B-1 cross-validation known-failures baseline
 # These decoder vectors are documented gaps in the accuracy guarantee
-# accept/reject logic (see docs/TESTING.md 'Known Gaps' and GOTCHAS.md #21).
+# accept/reject logic (see docs/CONFORMANCE.md 'Known Gaps' and GOTCHAS.md #21).
 # The runner passes when actual failures match this list exactly.
 # Remove entries as they are fixed; never add entries without investigation.
 decoder_sequence_08724.raw+large_f

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,0 +1,88 @@
+# CCSDS 124.0-B-1 Conformance
+
+This document is the **standard-conformance evidence** for this project: which standard is implemented, how conformance is demonstrated, and where the known gaps are.
+
+For the engineering test report (unit, malformed-input, robustness, packet-loss, fuzzing, reference-vector, and CCSDS-style generation tests), see [TESTING.md](TESTING.md). For the byte-level implementation pitfalls, see the [Implementer's Guide](GOTCHAS.md).
+
+## Standard conformed to
+
+**CCSDS 124.0-B-1**, *Robust Compression of Fixed-Length Housekeeping Data* — Blue Book, Issue 1, February 2023 ([PDF](https://ccsds.org/Pubs/124x0b1.pdf)). The algorithm is based on ESA's patented POCKET+.
+
+## How conformance is demonstrated
+
+Two independent, complementary checks:
+
+1. **Byte-identical output to the ESA reference implementation.** The C implementation produces output identical, byte for byte, to ESA/ESOC's original C reference ([`test-vector-generator/c-reference/`](../test-vector-generator/c-reference/)) across all five shared reference vectors (simple, housekeeping, edge-cases, hiro, venus-express) and all robustness levels R=0–7. The other five implementations (C++, Python, Go, Rust, Java) are validated byte-for-byte against the same shared [test vectors](../test-vectors/). Per-vector detail: [TESTING.md → Reference Test Vectors](TESTING.md#reference-test-vectors) and [→ Robustness Parameter Tests](TESTING.md#robustness-parameter-r0-7-tests).
+2. **The UAB/CNES cross-validation suite** — the standard's own conformance test bench, described below.
+
+## CCSDS Cross-Validation
+
+**Goal**: Validate byte-for-byte correctness against the comprehensive CCSDS 124.0-B-1 cross-validation test suite produced by the Universitat Autònoma de Barcelona (UAB) team under the technical supervision of CNES.
+
+**Method**: Run encoder and decoder harnesses against all test vectors. Compare generated output file sizes and SHA-256 hashes against the canonical manifest (`file_list.csv`).
+
+**Source**: [crossvalidation/](../crossvalidation/)
+
+**Run**:
+```bash
+# Docker (recommended)
+docker-compose run --rm c-crossvalidation
+
+# Local
+cd implementations/c
+make crossvalidation \
+  CROSSVAL_DIR=../../crossvalidation/c \
+  CROSSVAL_SCRIPT=../../crossvalidation/run_crossvalidation.sh
+```
+
+**Prerequisites**: The cross-validation data (`ccsds124_full_crossvalidation/`) must be obtained separately and placed at the project root. See [crossvalidation/README.md](../crossvalidation/README.md) for details.
+
+**Result**: Pass (encoder 100%, decoder 89.0% — matches known-failures baseline)
+
+| Direction | Passed | Total | Rate | Description |
+|-----------|--------|-------|------|-------------|
+| Encoder | 7,935 | 7,935 | 100% | Compress `.raw+config` → `.124`, validate size + SHA-256 |
+| Decoder | 15,102 | 16,965 | 89.0% | Decompress `.124+config` → `.raw+large_f`, validate size + SHA-256 |
+
+**Total**: 23,037 of 24,900 cross-validation vectors passed
+
+The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #18, #19, #20, and #21).
+
+### Reverse-Engineered Validation Rules
+
+Three reference-decoder behaviors were reverse-engineered from the test vectors (improving the decoder from 14,924 to 15,102) and are implemented in `ccsds124_discover_packet_length()` and `ccsds124_decompress_packet_checked()`:
+
+1. **Truncated reference packets still signal F**: when the bitstream runs out after `COUNT(F)` but before the full `I_t`, the signaled length "is to be considered" (cross-validation README). Reported as `CCSDS124_STATUS_TRUNCATED_LENGTH` for the output trailer.
+2. **Signaled-length validity (v1.6)**: a signaled `COUNT(F)` is trusted only if in range (1–65535) and consistent with the packet's own RLE spans (X_t span ≤ F, full-mask span ≤ F).
+3. **Reference packets tolerate excess trailing bits**: `rt=1` packets are self-delimiting via `COUNT(F)`; an oversized Received Packet Length means the remainder is ignored. Compressed (`rt=0`) packets keep the strict ≤7-padding-bits rule (v1.10).
+
+### Known Gaps (1,863 decoder vectors)
+
+All remaining failures are in the **accuracy guarantee accept/reject logic** — deciding whether a decompressed packet's output is guaranteed (`0x00`) or unguaranteed (`0x01`) in the presence of corruption. The CCSDS 124.0-B-1 standard does not specify these decision rules, and they cannot be fully reverse-engineered from the expected output files alone. The failures split into:
+
+**~1,400 vectors — too strict** (we reject packets the reference accepts)
+
+Pattern: fuzzed packets with corrupt `COUNT(F)` values. We reject via `count_f_mismatch`; the reference accepts some of them via an unidentified validation path. Removing the `count_f_mismatch` check regresses (to ~12,926 passes) because many corrupt packets then produce wrong output from shifted bit offsets.
+
+**~460 vectors — too lenient** (we guarantee packets the reference rejects)
+
+Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees these via the `ft=1` branch of the reference-packet check. Making mask-inconsistency detection unconditional — or gating it on a mask-ever-initialized flag — regresses catastrophically (~3,600 vectors) because `ft=1` packets after heavy loss are legitimate resynchronization points. A clean-robustness-window gate was also tried with no effect.
+
+**16 vectors — unknown excess-rejection rule**: the reference rejects certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
+
+**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #21.
+
+Other known gaps:
+- Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
+- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #20) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+
+## Per-implementation conformance status
+
+| Implementation | Byte-identical to ESA reference | UAB cross-validation |
+|----------------|---------------------------------|----------------------|
+| C | Yes — 5 reference vectors, R=0–7 | Yes — encoder 100%, decoder 89.0% (see above) |
+| C++ | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
+| Python | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
+| Go | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
+| Rust | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
+| Java | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -11,7 +11,7 @@ Four things are referenced throughout — keep them distinct:
 - **The standard** — *CCSDS 124.0-B-1, Robust Compression of Fixed-Length Housekeeping Data* (Blue Book, February 2023), the normative specification. All section and equation citations in this guide refer to it.
 - **The ESA reference implementation** — ESA/ESOC's original C program in [`test-vector-generator/c-reference/`](../test-vector-generator/c-reference/) (`pocket_compress.c` / `pocket_decompress.c`). It is the **conformance oracle**: "byte-identical output" everywhere in this guide means identical to what this program produces. It is kept verbatim — not modified, and not one of the implementations below.
 - **This repository's implementations** — the six independent, interoperable implementations in [`implementations/`](../implementations/) (C, C++, Python, Go, Rust, Java) that this guide was written to get right.
-- **The UAB conformance suite** — a 24,900-vector cross-validation set (valid and invalid parameters, packet loss, fuzzed packets) produced by the UAB team under CNES supervision. The C implementation is additionally validated against it; see [Conformance & Testing](TESTING.md).
+- **The UAB conformance suite** — a 24,900-vector cross-validation set (valid and invalid parameters, packet loss, fuzzed packets) produced by the UAB team under CNES supervision. The C implementation is additionally validated against it; see [Conformance](CONFORMANCE.md).
 
 Each pitfall is tagged by where the requirement comes from:
 
@@ -1383,7 +1383,7 @@ On decompression failure or unguaranteed status: restore the decompressor state 
 ### 📊 Impact
 
 - **Cross-validation improvement:** Decoder pass count increased from 12,315 to 14,924, then to 15,102 with additional reverse-engineered rules (of 16,965 vectors)
-- **Remaining failures (1,863):** Fuzzed packets with corrupted `COUNT(F)` fields and complex mask synchronization edge cases where the reference implementation handles specific corruption patterns differently — see TESTING.md "Known Gaps" for the full categorization
+- **Remaining failures (1,863):** Fuzzed packets with corrupted `COUNT(F)` fields and complex mask synchronization edge cases where the reference implementation handles specific corruption patterns differently — see CONFORMANCE.md "Known Gaps" for the full categorization
 
 ### Additional Reverse-Engineered Rules (June 2026)
 

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -1,36 +1,18 @@
-# CCSDS 124.0-B-1 Implementation Guidelines
+# CCSDS 124.0-B-1 Porting & Build Notes
+
+Per-language build, test, and style notes for working on or porting the implementations. This is the *how to build it* companion to the other docs: for the byte-level pitfalls you must get right see the [Implementer's Guide](GOTCHAS.md), for the algorithm itself the [Algorithm Reference](ALGORITHM.md), and for conformance evidence [CONFORMANCE.md](CONFORMANCE.md).
 
 ## Before You Start
 
-**Read [GOTCHAS.md](GOTCHAS.md) first!** It documents 21 critical pitfalls that will cause your implementation to fail silently.
+**Read the [Implementer's Guide](GOTCHAS.md) first.** It documents the 21 byte-level pitfalls that will otherwise make your implementation fail silently.
 
 ## Validation Requirements
 
-Your implementation must produce **byte-for-byte identical output** to the reference for all test vectors:
-
-| Test Vector | Input | Expected Output | Parameters |
-|-------------|-------|-----------------|------------|
-| simple | 9,000 bytes | 641 bytes | R=1, pt=10, ft=20, rt=50 |
-| hiro | 9,000 bytes | 1,533 bytes | R=7, pt=10, ft=20, rt=50 |
-| housekeeping | 900,000 bytes | 223,078 bytes | R=2, pt=20, ft=50, rt=100 |
-| edge-cases | 45,000 bytes | 10,124 bytes | R=1, pt=10, ft=20, rt=50 |
-| venus-express | 13,608,000 bytes | 5,891,500 bytes | R=2, pt=20, ft=50, rt=100 |
-
-Test vectors location: `test-vectors/`
+Your implementation must produce **byte-for-byte identical output** to the ESA reference for all five reference vectors (in `test-vectors/`). The vectors, their parameters, and expected output sizes are listed in [TESTING.md → Reference Test Vectors](TESTING.md#reference-test-vectors); the overall conformance bar is in [CONFORMANCE.md](CONFORMANCE.md).
 
 ## Critical Implementation Details
 
-These are **not obvious** from the CCSDS spec:
-
-1. **Vt calculation** - Start from position Rt+1, not position 2
-2. **ct calculation** - Include current packet's pt flag (Vt+1 total entries)
-3. **kt extraction** - Use forward order (low to high position)
-4. **BE extraction** - Use reverse order (high to low position)
-5. **Flag counters** - Use countdown counters, not modulo arithmetic
-6. **Init phase** - First Rt+1 packets have ft=1, rt=1, pt=0
-7. **D₀ = 0** - Set prev_mask = mask at init so D₀ = M₀ XOR M₀ = 0
-8. **NOT masking** - MSB-aligned: mask high bits, not low bits, for non-byte-aligned vectors
-9. **Decoder validation** - Validate bitstream integrity (sufficient bits, valid RLE deltas, consumed padding) to reject corrupt packets per CCSDS cross-validation expectations
+The non-obvious, spec-divergent pitfalls — the Vₜ window, cₜ, kₜ extraction order, BE order, countdown counters, the init phase, D₀ = 0, MSB-aligned NOT, and decoder validation — are documented in full, with citations, examples, and fixes, in the [Implementer's Guide](GOTCHAS.md). Read it before implementing; this doc does not duplicate it.
 
 ## Implementation Checklist
 
@@ -208,18 +190,11 @@ mvn checkstyle:check      # Check style
 
 ## Documentation
 
-- `ALGORITHM.md` - Detailed algorithm description
-- `GOTCHAS.md` - Critical implementation pitfalls
+- [Implementer's Guide](GOTCHAS.md) — byte-level pitfalls and how to get byte-identical output
+- [Algorithm Reference](ALGORITHM.md) — encoding/decoding steps and equations
+- [Conformance](CONFORMANCE.md) — conformance evidence and cross-validation results
+- [Test Report](TESTING.md) — the engineering test suite
 
 ## Quick Debugging
 
-| Symptom | Likely Cause |
-|---------|--------------|
-| R=2 tests fail, R=1 passes | Vt starts at wrong position |
-| edge-cases fails, simple passes | ct missing current flag |
-| Bit-level errors mid-stream | kt using wrong extraction order |
-| Size off by 10%+ | Flag timing wrong |
-| First packet wrong with non-zero M₀ | D₀ = M₀ instead of 0 |
-| Non-byte-aligned F fails | NOT masks low bits not high |
-
-See [GOTCHAS.md](GOTCHAS.md) for detailed diagnosis.
+See the [Implementer's Guide → Common Symptoms and Diagnosis](GOTCHAS.md#common-symptoms-and-diagnosis) for the symptom → cause → fix table.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,12 @@ Shared documentation for all CCSDS 124.0-B-1 implementations.
 
 ## Contents
 
-- [Algorithm](ALGORITHM.md) - Algorithm specification and details
-- [Guidelines](GUIDELINES.md) - Implementation quick start
-- [Gotchas](GOTCHAS.md) - Critical pitfalls (read this first!)
-- [Benchmark](BENCHMARK.md) - Performance comparison across implementations
-- [Testing](TESTING.md) - Test report and validation procedures
+- [Implementer's Guide](GOTCHAS.md) - byte-level pitfalls; read this first if you are implementing CCSDS 124.0-B-1
+- [Algorithm Reference](ALGORITHM.md) - algorithm specification and details
+- [Conformance](CONFORMANCE.md) - conformance evidence and cross-validation results
+- [Test Report](TESTING.md) - engineering test report and validation procedures
+- [Porting & Build Notes](GUIDELINES.md) - per-language build, test, and style notes
+- [Benchmark](BENCHMARK.md) - performance comparison across implementations
 - [Cross-Validation](../crossvalidation/README.md) - CCSDS 124.0-B-1 cross-validation suite, runner, and known-failures baseline
 - [Test Vectors](../test-vectors/README.md) - Validation data
 - [Test Vector Generator](../test-vector-generator/README.md) - Deterministic test vector generation

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -238,66 +238,9 @@ python ../scripts/validate_ccsds_style.py --vectors ./vectors
 
 **Result**: Pass - Implementation correctly implements CCSDS 124.0-B-1 robustness semantics.
 
-## CCSDS Cross-Validation
+## CCSDS Cross-Validation & Conformance
 
-**Goal**: Validate byte-for-byte correctness against the comprehensive CCSDS 124.0-B-1 cross-validation test suite produced by the Universitat Autonoma de Barcelona (UAB) team.
-
-**Method**: Run encoder and decoder harnesses against all test vectors. Compare generated output file sizes and SHA-256 hashes against the canonical manifest (`file_list.csv`).
-
-**Source**: [crossvalidation/](../crossvalidation/)
-
-**Run**:
-```bash
-# Docker (recommended)
-docker-compose run --rm c-crossvalidation
-
-# Local
-cd implementations/c
-make crossvalidation \
-  CROSSVAL_DIR=../../crossvalidation/c \
-  CROSSVAL_SCRIPT=../../crossvalidation/run_crossvalidation.sh
-```
-
-**Prerequisites**: The cross-validation data (`ccsds124_full_crossvalidation/`) must be obtained separately and placed at the project root. See [crossvalidation/README.md](../crossvalidation/README.md) for details.
-
-**Result**: Pass (encoder 100%, decoder 89.0% — matches known-failures baseline)
-
-| Direction | Passed | Total | Rate | Description |
-|-----------|--------|-------|------|-------------|
-| Encoder | 7,935 | 7,935 | 100% | Compress `.raw+config` → `.124`, validate size + SHA-256 |
-| Decoder | 15,102 | 16,965 | 89.0% | Decompress `.124+config` → `.raw+large_f`, validate size + SHA-256 |
-
-**Total**: 23,037 of 24,900 cross-validation vectors passed
-
-The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #18, #19, #20, and #21).
-
-### Reverse-Engineered Validation Rules
-
-Three reference-decoder behaviors were reverse-engineered from the test vectors (improving the decoder from 14,924 to 15,102) and are implemented in `ccsds124_discover_packet_length()` and `ccsds124_decompress_packet_checked()`:
-
-1. **Truncated reference packets still signal F**: when the bitstream runs out after `COUNT(F)` but before the full `I_t`, the signaled length "is to be considered" (cross-validation README). Reported as `CCSDS124_STATUS_TRUNCATED_LENGTH` for the output trailer.
-2. **Signaled-length validity (v1.6)**: a signaled `COUNT(F)` is trusted only if in range (1–65535) and consistent with the packet's own RLE spans (X_t span ≤ F, full-mask span ≤ F).
-3. **Reference packets tolerate excess trailing bits**: `rt=1` packets are self-delimiting via `COUNT(F)`; an oversized Received Packet Length means the remainder is ignored. Compressed (`rt=0`) packets keep the strict ≤7-padding-bits rule (v1.10).
-
-### Known Gaps (1,863 decoder vectors)
-
-All remaining failures are in the **accuracy guarantee accept/reject logic** — deciding whether a decompressed packet's output is guaranteed (`0x00`) or unguaranteed (`0x01`) in the presence of corruption. The CCSDS 124.0-B-1 standard does not specify these decision rules, and they cannot be fully reverse-engineered from the expected output files alone. The failures split into:
-
-**~1,400 vectors — too strict** (we reject packets the reference accepts)
-
-Pattern: fuzzed packets with corrupt `COUNT(F)` values. We reject via `count_f_mismatch`; the reference accepts some of them via an unidentified validation path. Removing the `count_f_mismatch` check regresses (to ~12,926 passes) because many corrupt packets then produce wrong output from shifted bit offsets.
-
-**~460 vectors — too lenient** (we guarantee packets the reference rejects)
-
-Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees these via the `ft=1` branch of the reference-packet check. Making mask-inconsistency detection unconditional — or gating it on a mask-ever-initialized flag — regresses catastrophically (~3,600 vectors) because `ft=1` packets after heavy loss are legitimate resynchronization points. A clean-robustness-window gate was also tried with no effect.
-
-**16 vectors — unknown excess-rejection rule**: the reference rejects certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
-
-**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #21.
-
-Other known gaps:
-- Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
-- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #20) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+Standard-conformance evidence — the UAB/CNES cross-validation results, the reverse-engineered validation rules, and the documented decoder gaps (Known Gaps) — lives in **[CONFORMANCE.md](CONFORMANCE.md)**.
 
 ## Run All Tests
 


### PR DESCRIPTION
Closes #111. Also tightens up the doc set (a doc-naming collision the maintainer flagged).

### #111 — conformance as a single source of truth
- **New [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md)** — the standard-conformance evidence: the standard issue conformed to (124.0-B-1), byte-identical-to-ESA-reference, the UAB/CNES cross-validation results, the reverse-engineered validation rules, the **Known Gaps**, and a per-implementation status table.
- **Relocated** the cross-validation + Known Gaps sections out of `TESTING.md` (now a one-line pointer). `TESTING.md` stays the engineering test report.
- **README** gains a top-level **Conformance** section linking to it. To avoid drift, the README cites only the externally-fixed suite size (24,900 vectors); the pass counts (7,935 / 15,102 / 23,037) live only in `CONFORMANCE.md`.

### Doc-naming cleanup
- `GUIDELINES.md` ("Implementation Guidelines") was confusingly close to `GOTCHAS.md` ("Implementer's Guide"). Renamed to **"Porting & Build Notes"** and **de-duplicated**: its Validation Requirements, Critical Implementation Details, and Quick Debugging sections (which duplicated CONFORMANCE / the Implementer's Guide) are now pointers; its unique per-language build/test/style notes are kept.

### Reference updates (no broken links)
Repointed everything that referenced the moved content or the renamed doc: README "Documentation" list, `docs/README.md` index, `AGENTS.md` Important-Files list + its Known-Gaps reference, `CONTRIBUTING.md`, GOTCHAS #21 body, `crossvalidation/README.md`, and `known-failures.txt`.

### Verification (audited to convergence)
- Repo-wide markdown link/anchor integrity passes.
- No stale labels (`Implementation Guidelines` / `Conformance & Testing`) or dangling `TESTING.md#known-gaps` anchors anywhere.
- CONFORMANCE.md numbers are self-consistent (7,935+16,965=24,900; 7,935+15,102=23,037; 16,965−15,102=1,863).
- Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)