### PR TITLE
docs: add SECURITY.md, document the conformed standard issue, and correct stale decoder-hardening references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Conforms to **CCSDS 124.0-B-1** (Blue Book, February 2023), demonstrated two way
 
 ## Documentation
 
-- 📘 **[Implementer's Guide](docs/GOTCHAS.md)** — if you are implementing CCSDS 124.0-B-1 yourself, start here. It documents the 21 byte-level pitfalls (each tagged as spec-mandated or a reference-conformance detail, with section/equation citations) that you must get right to produce byte-identical output.
+- **[Implementer's Guide](docs/GOTCHAS.md)** — if you are implementing CCSDS 124.0-B-1 yourself, start here. It documents the 21 byte-level pitfalls (each tagged as spec-mandated or a reference-conformance detail, with section/equation citations) that you must get right to produce byte-identical output.
 - **[Algorithm Reference](docs/ALGORITHM.md)** — the encoding/decoding steps, equations, and worked examples.
 - **[Conformance](docs/CONFORMANCE.md)** — what the project conforms to and the evidence: byte-identical-to-reference plus the UAB/CNES cross-validation results and documented gaps.
 - **[Test Report](docs/TESTING.md)** — the engineering test suite: unit, malformed-input, robustness, packet-loss, fuzzing, and reference-vector tests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public issue.
+
+- Preferred: GitHub's private vulnerability reporting — open the repository's **Security** tab and choose **"Report a vulnerability"** ([Security Advisories](https://github.com/tanagraspace/ccsds124/security/advisories)).
+- Alternatively, email **georges@tanagraspace.com** with details and, ideally, a minimal reproducer.
+
+We will acknowledge your report and keep you updated as we investigate and remediate. Once a fix is available we will coordinate disclosure and credit reporters who wish to be named.
+
+## Supported Versions
+
+All six implementations are released together at the same version. Security fixes are applied to the latest released line only.
+
+| Version | Supported |
+|---------|-----------|
+| 1.0.x   | ✅        |
+| < 1.0   | ❌ (pre-release) |
+
+## Scope and threat model
+
+This project is a **lossless compression library** for fixed-length housekeeping telemetry (CCSDS 124.0-B-1). It has **no network, daemon, or privileged surface** — it compresses and decompresses byte buffers in-process. The relevant attack surface is therefore **processing untrusted or malformed input**, most importantly on the **decoder** (decompressing data received from a potentially lossy or hostile channel).
+
+Posture across the implementations:
+
+- **C** — uses static allocation only (no `malloc`/`free`), validates bitstream integrity to reject corrupt or truncated packets (see the [Implementer's Guide](docs/GOTCHAS.md) #20), and is checked with MISRA-C:2012, Valgrind, and continuous fuzzing (compress / decompress / round-trip harnesses, zero crashes observed).
+- **C++** — header-only with zero dynamic allocation, analyzed with clang-tidy (CERT / HIC++ / C++ Core Guidelines).
+- **Python, Go, Rust, Java** — memory-safe languages.
+
+All six decoders **validate bitstream integrity** — corrupt or truncated input is rejected with an error rather than producing silent garbage (RLE-delta bounds and underflow checks). What is currently **C-only** is the higher-level *accuracy-guarantee* layer that decides whether a decompressed packet's output is reliable after packet loss or corruption; the other five languages do not yet make that determination. This is a correctness/feature gap, not memory unsafety, and is tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93). See [CONFORMANCE.md](docs/CONFORMANCE.md) for details.
+
+In all cases, treat the output of decompressing untrusted input as untrusted until validated by your application.

--- a/crossvalidation/cpp/README.md
+++ b/crossvalidation/cpp/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the C++ implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the C++ implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+The decoder bitstream hardening (GOTCHAS.md #20) is complete (#92). The C++ cross-validation harness — and the accuracy-guarantee layer it needs — is tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) (blocked on #89).

--- a/crossvalidation/go/README.md
+++ b/crossvalidation/go/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Go implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Go implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+The decoder bitstream hardening (GOTCHAS.md #20) is complete (#92). The Go cross-validation harness — and the accuracy-guarantee layer it needs — is tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) (blocked on #89).

--- a/crossvalidation/java/README.md
+++ b/crossvalidation/java/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Java implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Java implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+The decoder bitstream hardening (GOTCHAS.md #20) is complete (#92). The Java cross-validation harness — and the accuracy-guarantee layer it needs — is tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) (blocked on #89).

--- a/crossvalidation/rust/README.md
+++ b/crossvalidation/rust/README.md
@@ -2,4 +2,4 @@
 
 TODO: Implement the cross-validation harness for the Rust implementation — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)).
 
-Prerequisite: port the decoder bitstream hardening (GOTCHAS.md #20) to the Rust implementation — tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+The decoder bitstream hardening (GOTCHAS.md #20) is complete (#92). The Rust cross-validation harness — and the accuracy-guarantee layer it needs — is tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) (blocked on #89).

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -8,6 +8,8 @@ For the engineering test report (unit, malformed-input, robustness, packet-loss,
 
 **CCSDS 124.0-B-1**, *Robust Compression of Fixed-Length Housekeeping Data* — Blue Book, Issue 1, February 2023 ([PDF](https://ccsds.org/Pubs/124x0b1.pdf)). The algorithm is based on ESA's patented POCKET+.
 
+This implementation conforms specifically to **Issue 1 (the `-B-1` suffix)**. The `124.0` series number is stable; the issue suffix would change only if CCSDS publishes a corrigendum or a future re-issue (e.g. `124.0-B-2`). Any such change — and any conformance impact — will be tracked via the [issue tracker](https://github.com/tanagraspace/ccsds124/issues) and reflected here.
+
 ## How conformance is demonstrated
 
 Two independent, complementary checks:
@@ -74,7 +76,7 @@ Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees 
 
 Other known gaps:
 - Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
-- The C++/Python/Go/Rust/Java decoders do not yet validate bitstream integrity (GOTCHAS.md #20) — corrupt input can produce silent wrong output instead of an error. Tracked in [#92](https://github.com/tanagraspace/ccsds124/issues/92).
+- The C++/Python/Go/Rust/Java decoders validate bitstream integrity — corrupt or truncated input is rejected with an error (RLE-delta bounds and underflow checks, completed in [#92](https://github.com/tanagraspace/ccsds124/issues/92)). They do not yet implement the C decoder's full **accuracy-guarantee** layer (the guaranteed/unguaranteed accept-reject decisions and padding verification); that moves with [#93](https://github.com/tanagraspace/ccsds124/issues/93).
 
 ## Per-implementation conformance status
 


### PR DESCRIPTION
Closes #120.

### SECURITY.md (new, repo root)
GitHub auto-surfaces a root `SECURITY.md`. Covers:
- **Reporting** — private GitHub vulnerability advisory preferred, `georges@tanagraspace.com` fallback; no public issues for security. No specific response-time commitment.
- **Supported versions** — `1.0.x`.
- **Threat model** — in-process compression library, no network/daemon surface; the relevant surface is decompressing untrusted/malformed input. All six decoders validate bitstream integrity (reject corrupt/truncated input); the higher-level **accuracy-guarantee** layer is currently C-only (tracked in #93).

### CONFORMANCE.md — conformed standard issue
Notes that this conforms to **Issue 1 (`-B-1`)**, the `124.0` series number is stable, and a corrigendum / future `124.0-B-2` re-issue would be tracked via the issue tracker.

### Stale-reference correction (found while writing the threat model)
SECURITY.md, CONFORMANCE.md, and the four `crossvalidation/<lang>/README.md` placeholders claimed the C++/Python/Go/Rust/Java decoders "do not yet validate bitstream integrity (tracked in #92)". **#92 is closed/complete** — bitstream validation (RLE-delta + underflow) is present in all six languages. Corrected those to point the *remaining* C-only gap (the accuracy-guarantee layer) at #93. Left a doc-dependency note on #93 and a forward-pointer on #92.

### Also
- Removed the 📘 emoji from the README Implementer's Guide link.

No `ROADMAP.md` (per the issue). Documentation only; markdown link/anchor integrity verified repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)