### PR TITLE
chore: add CITATION.cff (paper-first), README paper badge, and reframe About

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+message: >-
+  This repository implements the CCSDS 124.0-B-1 standard. If you use it in
+  academic work, please cite the paper below (Evans et al., 2022) rather than
+  the software or the repository.
+title: "CCSDS 124.0-B-1: multi-language implementations of the lossless housekeeping compression standard"
+abstract: >-
+  Independent, interoperable implementations (C, C++, Python, Go, Rust, Java) of
+  the CCSDS 124.0-B-1 lossless compression standard for fixed-length spacecraft
+  housekeeping telemetry, based on ESA's patented POCKET+ algorithm.
+type: software
+authors:
+  - family-names: "Labrèche"
+    given-names: "Georges"
+    affiliation: "Tanagra Space"
+repository-code: "https://github.com/tanagraspace/ccsds124"
+url: "https://tanagraspace.com/ccsds124"
+license: MIT
+version: "1.0.0"
+preferred-citation:
+  type: conference-paper
+  title: "Implementing the New CCSDS Housekeeping Data Compression Standard 124.0-B-1 (based on POCKET+) on OPS-SAT-1"
+  authors:
+    - family-names: "Evans"
+      given-names: "David"
+    - family-names: "Labrèche"
+      given-names: "Georges"
+    - family-names: "Marszk"
+      given-names: "Dominik"
+    - family-names: "Bammens"
+      given-names: "Samuel"
+    - family-names: "Hernandez-Cabronero"
+      given-names: "Miguel"
+    - family-names: "Zelenevskiy"
+      given-names: "Vladimir"
+    - family-names: "Shiradhonkar"
+      given-names: "Vasundhara"
+    - family-names: "Starcik"
+      given-names: "Mario"
+    - family-names: "Henkel"
+      given-names: "Maximilian"
+  collection-title: "Proceedings of the Small Satellite Conference"
+  conference:
+    name: "36th Annual Small Satellite Conference"
+  year: 2022
+  notes: "SSC22-XII-03"
+  url: "https://digitalcommons.usu.edu/smallsat/2022/all2022/133/"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CCSDS 124.0-B-1
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Paper: SmallSat 2022](https://img.shields.io/badge/SmallSat_2022-CCSDS_124.0--B--1-blue)](https://digitalcommons.usu.edu/smallsat/2022/all2022/133/)
 
 The definitive implementation of the [CCSDS 124.0-B-1](https://ccsds.org/Pubs/124x0b1.pdf) lossless compression algorithm of fixed-length housekeeping data.
 
@@ -28,9 +29,9 @@ If CCSDS 124.0-B-1 contributes to your research, please cite:
 
 ## About
 
-POCKET+ is an European Space Agency (ESA) patented lossless compression algorithm implemented using very low-level instructions such as OR, XOR, AND, etc. It has been designed to run on spacecraft command and control processors with low CPU power available and tight real-time constraints. An earlier version of POCKET+ was flight-proven onboard both the Nanomind 3200 flight computer and SEPP payload computer of ESA's OPS-SAT-1 spacecraft.
+CCSDS 124.0-B-1 is the CCSDS standard for lossless compression of fixed-length spacecraft housekeeping data. It standardizes **POCKET+**, an European Space Agency (ESA) patented algorithm implemented using very low-level instructions such as OR, XOR, AND, etc., designed to run on spacecraft command and control processors with low CPU power available and tight real-time constraints.
 
-The algorithm has been standardized by CCSDS as **CCSDS 124.0-B-1** for compressing fixed-length spacecraft housekeeping packets.
+An earlier version of POCKET+ was flight-proven onboard both the Nanomind 3200 flight computer and SEPP payload computer of ESA's OPS-SAT-1 spacecraft.
 
 ## Conformance
 


### PR DESCRIPTION
Closes #113.

### CITATION.cff (paper-first)
Root `CITATION.cff` so GitHub's **"Cite this repository"** sidebar widget (and CFF-aware tools) surface the **Evans 2022 SmallSat paper** — not the software or repo URL. (CITATION.cff itself renders **no badge**, only the sidebar widget.)
- `preferred-citation` = the conference paper (D. Evans et al., SSC22-XII-03, DigitalCommons URL), full 9-author list matching the README BibTeX.
- `message` explicitly asks people to cite the paper, not the repository.
- Minimal software metadata, **no DOI / no Zenodo** — a competing software citation would siphon counts from the paper's Google Scholar record.
- Validated with `cffconvert` (schema 1.2.0).

### README paper badge
Adds a visible, clickable badge **`SmallSat 2022 | CCSDS 124.0-B-1`** (blue) next to the License badge, linking to the paper on DigitalCommons.

### README "About" reframe
Leads with the standard (CCSDS 124.0-B-1) and presents **POCKET+** as the ESA-patented algorithm it standardizes — keeping the POCKET+ provenance and OPS-SAT-1 flight heritage. The Evans 2022 citation/BibTeX (title contains "based on POCKET+") is unchanged.

Documentation/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)