### PR TITLE
chore: v1.0.0 release prep (changelog dates + MIT license note)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,7 @@
   <div class="content">
     <p>The definitive implementation of the <a href="https://ccsds.org/Pubs/124x0b1.pdf">CCSDS 124.0-B-1</a> lossless compression algorithm of fixed-length housekeeping data.</p>
     <br>
-    <p>CCSDS 124.0-B-1 is patented by the <a href="https://www.esa.int/">European Space Agency (ESA)</a>, standardized by the <a href="https://ccsds.org/">Consultative Committee for Space Data Systems (CCSDS)</a>, and implemented by <a href="https://georges.fyi">georges.fyi</a> at <a href="https://tanagraspace.com/">Tanagra Space</a>.</p>
+    <p>Designed by the <a href="https://www.esa.int/">European Space Agency (ESA)</a>, implemented on the OPS-SAT-1 flight computer by <a href="https://georges.fyi">georges.fyi</a>, and flight validated in orbit, CCSDS 124.0-B-1 was then standardized by the <a href="https://ccsds.org/">Consultative Committee for Space Data Systems (CCSDS)</a>. The implementations here are also by georges.fyi at <a href="https://tanagraspace.com/">Tanagra Space</a>, under the <a href="https://github.com/tanagraspace/ccsds124/blob/main/LICENSE">MIT License</a>.</p>
 
     <h2>Citation</h2>
     <p>If CCSDS 124.0-B-1 contributes to your research, please cite:</p>

--- a/implementations/c/CHANGELOG.md
+++ b/implementations/c/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `c/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 

--- a/implementations/cpp/CHANGELOG.md
+++ b/implementations/cpp/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `cpp/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 

--- a/implementations/go/CHANGELOG.md
+++ b/implementations/go/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `go/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 

--- a/implementations/java/CHANGELOG.md
+++ b/implementations/java/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `java/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 

--- a/implementations/python/CHANGELOG.md
+++ b/implementations/python/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `python/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 

--- a/implementations/rust/CHANGELOG.md
+++ b/implementations/rust/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases are tagged `rust/vX.Y.Z`.
 
-## [1.0.0] - 2026-06-07
+## [1.0.0] - 2026-06-13
 
 ### Added
 


### PR DESCRIPTION
Prep for tagging and releasing v1.0.0 across all six implementations.

## Changes

- **CHANGELOG dates** — the six `## [1.0.0]` entries carried `2026-06-07` from when 1.0.0 was staged. Corrected to the actual release date, `2026-06-13`, so the GitHub Release notes (generated from these sections) carry the right date.
- **Landing page (`docs/index.html`)**:
  - Added a note that the implementations in this project are released under the MIT License.
  - Fixed the provenance line. It previously said CCSDS 124.0-B-1 is patented by ESA, which is misleading. The patent is on POCKET+, the ESA algorithm that CCSDS 124.0-B-1 standardizes, consistent with the README and the docs.

## After this merges

I will tag v1.0.0 at the resulting main commit using the repo's independent-versioning scheme:

- `c/v1.0.0`, `cpp/v1.0.0`, `python/v1.0.0`, `rust/v1.0.0`, `java/v1.0.0`
- `implementations/go/v1.0.0` (the path-prefixed form Go's module resolver needs, per CONTRIBUTING.md)

and create a GitHub Release per tag from the corresponding CHANGELOG 1.0.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)