### PR TITLE
docs: clarify UAB/CNES decoder compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ make crossvalidation
 
 The runner script writes a results file (defaults to `build/crossvalidation-results.txt` when invoked via `make`). Override via `RESULTS_FILE` env var. The file contains a header (date, binaries, mode), per-phase pass/fail counts, failure details, and a final PASS/FAIL verdict.
 
-The verdict honors the known-failures baseline (`crossvalidation/known-failures.txt`): failures that match the baseline exactly produce **PASS (matches known-failures baseline)**; only regressions or new failures produce **FAIL**. The baseline entries are documented gaps in the decoder accuracy guarantee logic (see `docs/CONFORMANCE.md` Known Gaps).
+The verdict honors the known-failures baseline (`crossvalidation/known-failures.txt`): failures that match the baseline exactly produce **PASS (matches known-failures baseline)**; only regressions or new failures produce **FAIL**. The baseline entries are documented UAB/CNES compatibility gaps in decoder malformed-input accept/reject behavior (see `docs/CONFORMANCE.md` Known Gaps).
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An earlier version of POCKET+ was flight-proven onboard both the Nanomind 3200 f
 
 ## Conformance
 
-Conforms to **CCSDS 124.0-B-1** (Blue Book, February 2023), demonstrated two ways: **byte-identical output to the ESA reference implementation** on all shared reference vectors, and validation against the **UAB/CNES cross-validation suite** — the standard's own 24,900-vector test bench. Full results, the standard issue conformed to, per-implementation status, and documented gaps are in **[CONFORMANCE.md](docs/CONFORMANCE.md)**.
+Conforms to **CCSDS 124.0-B-1** (Blue Book, February 2023), demonstrated two ways: **byte-identical output to the ESA reference implementation** on all shared reference vectors, and validation against the **UAB/CNES cross-validation suite** — a 24,900-vector compatibility test bench for CCSDS 124.0-B-1 implementations. Full results, the standard issue conformed to, per-implementation status, and documented gaps are in **[CONFORMANCE.md](docs/CONFORMANCE.md)**.
 
 ## Documentation
 

--- a/crossvalidation/README.md
+++ b/crossvalidation/README.md
@@ -8,7 +8,7 @@ Cross-validation against the comprehensive test vector suite produced by the Uni
 crossvalidation/
   README.md                 # This file
   file_list.csv             # Canonical manifest (expected sizes + SHA-256 hashes)
-  known-failures.txt        # Documented-gap baseline (1,863 decoder vectors)
+  known-failures.txt        # Documented UAB/CNES compatibility-gap baseline (1,863 decoder vectors)
   run_crossvalidation.sh    # Shared runner script (parameterized for binary paths)
   c/                        # C implementation harness
   cpp/                      # C++ implementation harness (TODO: #93)
@@ -18,7 +18,7 @@ crossvalidation/
   sandbox/                  # Original ESA reference code harness
 ```
 
-Harnesses for the other languages are tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) — deliberately deferred until the C accept/reject ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)), with decoder bitstream hardening ([#92](https://github.com/tanagraspace/ccsds124/issues/92)) as a prerequisite.
+Harnesses for the other languages are tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) — deliberately deferred until the C UAB/CNES compatibility ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)), with decoder bitstream hardening ([#92](https://github.com/tanagraspace/ccsds124/issues/92)) as a prerequisite.
 
 ## Test Vectors
 
@@ -67,7 +67,7 @@ ENCODER_BIN=./build/encoder DECODER_BIN=./build/decoder bash crossvalidation/run
 
 ## Known-Failures Baseline
 
-The C decoder has **1,863 documented gaps** in the accuracy guarantee accept/reject logic (see [docs/CONFORMANCE.md](../docs/CONFORMANCE.md#known-gaps-1863-decoder-vectors) for the full analysis). These vector names are recorded in `known-failures.txt`. The runner's verdict is:
+The C decoder has **1,863 documented UAB/CNES compatibility gaps** in the malformed-input accept/reject logic (see [docs/CONFORMANCE.md](../docs/CONFORMANCE.md#known-gaps-1863-decoder-vectors) for the full analysis). These vector names are recorded in `known-failures.txt`. The runner's verdict is:
 
 - **PASS** — zero failures
 - **PASS (matches known-failures baseline)** — every failure is listed in the baseline; any baseline entries that now pass are reported so the file can be trimmed

--- a/crossvalidation/known-failures.txt
+++ b/crossvalidation/known-failures.txt
@@ -1,6 +1,7 @@
 # CCSDS 124.0-B-1 cross-validation known-failures baseline
-# These decoder vectors are documented gaps in the accuracy guarantee
-# accept/reject logic (see docs/CONFORMANCE.md 'Known Gaps' and GOTCHAS.md #21).
+# These decoder vectors are documented UAB/CNES compatibility gaps in
+# malformed-input accept/reject behavior (see docs/CONFORMANCE.md 'Known Gaps'
+# and GOTCHAS.md #21).
 # The runner passes when actual failures match this list exactly.
 # Remove entries as they are fixed; never add entries without investigation.
 decoder_sequence_08724.raw+large_f

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,11 +15,11 @@ This implementation conforms specifically to **Issue 1 (the `-B-1` suffix)**. Th
 Two independent, complementary checks:
 
 1. **Byte-identical output to the ESA reference implementation.** The C implementation produces output identical, byte for byte, to ESA/ESOC's original C reference ([`test-vector-generator/c-reference/`](../test-vector-generator/c-reference/)) across all five shared reference vectors (simple, housekeeping, edge-cases, hiro, venus-express) and all robustness levels R=0–7. The other five implementations (C++, Python, Go, Rust, Java) are validated byte-for-byte against the same shared [test vectors](../test-vectors/). Per-vector detail: [TESTING.md → Reference Test Vectors](TESTING.md#reference-test-vectors) and [→ Robustness Parameter Tests](TESTING.md#robustness-parameter-r0-7-tests).
-2. **The UAB/CNES cross-validation suite** — the standard's own conformance test bench, described below.
+2. **The UAB/CNES cross-validation suite** — a CCSDS 124.0-B-1 compatibility test bench, described below.
 
 ## CCSDS Cross-Validation
 
-**Goal**: Validate byte-for-byte correctness against the comprehensive CCSDS 124.0-B-1 cross-validation test suite produced by the Universitat Autònoma de Barcelona (UAB) team under the technical supervision of CNES.
+**Goal**: Validate byte-for-byte compatibility against the comprehensive CCSDS 124.0-B-1 cross-validation test suite produced by the Universitat Autònoma de Barcelona (UAB) team under the technical supervision of CNES.
 
 **Method**: Run encoder and decoder harnesses against all test vectors. Compare generated output file sizes and SHA-256 hashes against the canonical manifest (`file_list.csv`).
 
@@ -39,7 +39,7 @@ make crossvalidation \
 
 **Prerequisites**: The cross-validation data (`ccsds124_full_crossvalidation/`) must be obtained separately and placed at the project root. See [crossvalidation/README.md](../crossvalidation/README.md) for details.
 
-**Result**: Pass (encoder 100%, decoder 89.0% — matches known-failures baseline)
+**Result**: Encoder passes fully; decoder matches 89.0% of UAB/CNES expected outputs, with remaining known gaps documented below.
 
 | Direction | Passed | Total | Rate | Description |
 |-----------|--------|-------|------|-------------|
@@ -48,11 +48,11 @@ make crossvalidation \
 
 **Total**: 23,037 of 24,900 cross-validation vectors passed
 
-The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #18, #19, #20, and #21).
+The encoder passes all 7,935 vectors. The decoder passes 15,102 of 16,965 vectors. The remaining 1,863 failures are documented UAB/CNES compatibility gaps recorded in `crossvalidation/known-failures.txt` — the runner reports **PASS (matches known-failures baseline)** when actual failures match that list exactly, and **FAIL** only on regressions or new failures. The suite covers valid and invalid parameters, non-byte-aligned packet lengths, non-zero initial masks, packet loss scenarios, and edge cases. Four gotchas were discovered and fixed during cross-validation (see [GOTCHAS.md](GOTCHAS.md) #18, #19, #20, and #21).
 
 ### Reverse-Engineered Validation Rules
 
-Three reference-decoder behaviors were reverse-engineered from the test vectors (improving the decoder from 14,924 to 15,102) and are implemented in `ccsds124_discover_packet_length()` and `ccsds124_decompress_packet_checked()`:
+Three UAB/CNES decoder behaviors were reverse-engineered from the test vectors (improving the decoder from 14,924 to 15,102) and are implemented in `ccsds124_discover_packet_length()` and `ccsds124_decompress_packet_checked()`:
 
 1. **Truncated reference packets still signal F**: when the bitstream runs out after `COUNT(F)` but before the full `I_t`, the signaled length "is to be considered" (cross-validation README). Reported as `CCSDS124_STATUS_TRUNCATED_LENGTH` for the output trailer.
 2. **Signaled-length validity (v1.6)**: a signaled `COUNT(F)` is trusted only if in range (1–65535) and consistent with the packet's own RLE spans (X_t span ≤ F, full-mask span ≤ F).
@@ -60,19 +60,19 @@ Three reference-decoder behaviors were reverse-engineered from the test vectors 
 
 ### Known Gaps (1,863 decoder vectors)
 
-All remaining failures are in the **accuracy guarantee accept/reject logic** — deciding whether a decompressed packet's output is guaranteed (`0x00`) or unguaranteed (`0x01`) in the presence of corruption. The CCSDS 124.0-B-1 standard does not specify these decision rules, and they cannot be fully reverse-engineered from the expected output files alone. The failures split into:
+All remaining failures are in the **UAB/CNES decoder accept/reject logic** — deciding whether a decompressed packet's output is reported as guaranteed (`0x00`) or unguaranteed (`0x01`) in the presence of malformed or ambiguous compressed input. The CCSDS 124.0-B-1 Blue Book defines the compressed format and packet-loss robustness semantics, but does not appear to specify a precise decoder status policy for corrupt bitstreams. These remaining decoder gaps are therefore treated as UAB/CNES cross-validation compatibility gaps, not as evidence of normative CCSDS non-conformance. They cannot be fully reverse-engineered from the expected output files alone. The failures split into:
 
-**~1,400 vectors — too strict** (we reject packets the reference accepts)
+**~1,400 vectors — too strict** (we reject packets the UAB/CNES expected outputs accept)
 
-Pattern: fuzzed packets with corrupt `COUNT(F)` values. We reject via `count_f_mismatch`; the reference accepts some of them via an unidentified validation path. Removing the `count_f_mismatch` check regresses (to ~12,926 passes) because many corrupt packets then produce wrong output from shifted bit offsets.
+Pattern: fuzzed packets with corrupt `COUNT(F)` values. We reject via `count_f_mismatch`; the UAB/CNES expected outputs accept some of them via an unidentified validation path. Removing the `count_f_mismatch` check regresses (to ~12,926 passes) because many corrupt packets then produce wrong output from shifted bit offsets.
 
-**~460 vectors — too lenient** (we guarantee packets the reference rejects)
+**~460 vectors — too lenient** (we guarantee packets the UAB/CNES expected outputs reject)
 
 Pattern: `rt=1, ft=1, mask_inconsistent=1, mask_synced=0`. Our logic guarantees these via the `ft=1` branch of the reference-packet check. Making mask-inconsistency detection unconditional — or gating it on a mask-ever-initialized flag — regresses catastrophically (~3,600 vectors) because `ft=1` packets after heavy loss are legitimate resynchronization points. A clean-robustness-window gate was also tried with no effect.
 
-**16 vectors — unknown excess-rejection rule**: the reference rejects certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
+**16 vectors — unknown excess-rejection rule**: the UAB/CNES expected outputs reject certain `rt=1` packets with small excess bit counts (48–344) after F is established, while accepting large excesses (4K–64K) on the stream's first valid reference packet. The exact discriminator is unidentified; these 16 are accepted as a trade-off for the 118 vectors the excess-tolerance rule fixes.
 
-**Path to 100%:** requires access to the UAB reference decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #21.
+**Path to full UAB/CNES decoder compatibility:** requires access to the UAB decoder source (or its accept/reject decision rules) — the categories interact, and rule combinations beyond the three implemented above produced net regressions. Tracked in [#89](https://github.com/tanagraspace/ccsds124/issues/89); see also GOTCHAS.md #21.
 
 Other known gaps:
 - Cross-validation harnesses for C++, Python, Go, Rust, and Java are not yet implemented (`crossvalidation/<lang>/` are placeholders) — tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93), deferred until #89 resolves. Those implementations are validated via the shared `test-vectors/` only.
@@ -82,7 +82,7 @@ Other known gaps:
 
 | Implementation | Byte-identical to ESA reference | UAB cross-validation |
 |----------------|---------------------------------|----------------------|
-| C | Yes — 5 reference vectors, R=0–7 | Yes — encoder 100%, decoder 89.0% (see above) |
+| C | Yes — 5 reference vectors, R=0–7 | Encoder 100%, decoder 89.0% UAB/CNES compatibility (see above) |
 | C++ | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
 | Python | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |
 | Go | Yes — shared test vectors | Not yet — harness tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) |

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -1294,14 +1294,14 @@ result_byte = (~input_byte) & byte_mask;
 
 ## 20. Decoder Must Validate Bitstream Integrity to Reject Corrupt Packets
 
-🔧 **Conformance detail** — the standard does not specify decoder error handling; rejecting corrupt bitstreams is required to pass the cross-validation suite.
+🔧 **Conformance detail** — the standard does not specify decoder error handling; rejecting corrupt bitstreams is required for UAB/CNES cross-validation compatibility.
 
 **Category:** Decompression
 **Discovery:** CCSDS cross-validation (decoder vectors include intentionally corrupt/fuzzed packets)
 
 ### The Problem
 
-The CCSDS 124.0-B-1 decoder must not silently produce wrong output when given corrupt compressed data. The UAB reference decoder implements strict validation checks (documented in README_crossvalidation.md v1.4-v1.13) that reject invalid packets. Without these checks, the decoder happily decompresses garbage into wrong output, causing cross-validation failures where the expected behavior is an error status (0x01).
+For UAB/CNES cross-validation compatibility, a CCSDS 124.0-B-1 decoder must not silently produce wrong output when given corrupt compressed data. The UAB decoder implements strict validation checks (documented in README_crossvalidation.md v1.4-v1.13) that reject invalid packets. Without these checks, the decoder happily decompresses garbage into wrong output, causing cross-validation failures where the UAB/CNES expected output records an error status (0x01).
 
 ### Three Categories of Validation
 
@@ -1343,14 +1343,14 @@ bitvector_set_bit(result, bit_position, 1);
 
 ## 21. Decoder Cross-Validation: Mask Synchronization and Accuracy Guarantees
 
-🔧 **Conformance detail** — §2 defines the accuracy guarantee (a packet stays decodable after ≤ the effective robustness level of consecutive losses); the exact accept/reject decision rules are underspecified in the standard and were reverse-engineered from the conformance vectors.
+🔧 **Conformance detail** — §2 defines the accuracy guarantee (a packet stays decodable after ≤ the effective robustness level of consecutive losses); the exact decoder status policy for corrupt bitstreams is underspecified in the standard and was reverse-engineered from the UAB/CNES cross-validation vectors.
 
 **Category:** Decompression
 **Discovery:** CCSDS cross-validation (decoder vectors with unknown initial mask and fuzzed packets)
 
 ### The Problem
 
-When the decoder doesn't know the encoder's initial mask (`large_m_0`), it starts with an all-zero mask. This creates a mask desynchronization that persists until a full mask transmission (`ft=1`) is received. A naive decoder that ignores desynchronization will produce too many "guaranteed" outputs (status `0x00`) for packets that the reference decoder correctly marks as unguaranteed (`0x01`).
+When the decoder doesn't know the encoder's initial mask (`large_m_0`), it starts with an all-zero mask. This creates a mask desynchronization that persists until a full mask transmission (`ft=1`) is received. A naive decoder that ignores desynchronization will produce too many "guaranteed" outputs (status `0x00`) for packets that the UAB/CNES expected outputs mark as unguaranteed (`0x01`).
 
 ### Library Support
 
@@ -1366,16 +1366,16 @@ These behaviors are handled automatically by `ccsds124_decompress_packet_checked
 The decoder must track whether its mask has been synchronized with the encoder's via a full mask transmission (`ft=1`). Start with `mask_synced=0`. Set to `1` only when a guaranteed (`0x00`) packet with `ft=1` is successfully decoded. Reset to `0` on decompression failure, packet loss, or mask inconsistency detection.
 
 **2. Reference packet guarantee (rt=1):**
-A reference packet (uncompressed, `rt=1`) is only guaranteed if the mask is synchronized (`mask_synced=1`) or the packet itself provides a full mask (`ft=1`) to resynchronize. Without this check, desynchronized decoders incorrectly accept reference packets.
+A reference packet (uncompressed, `rt=1`) is treated as guaranteed by the UAB/CNES expected outputs only if the mask is synchronized (`mask_synced=1`) or the packet itself provides a full mask (`ft=1`) to resynchronize. Without this check, desynchronized decoders incorrectly accept reference packets for cross-validation purposes.
 
 **3. Mask inconsistency detection (ft=1):**
-When `ft=1`, compare the delta-updated mask with the full mask received. If they differ (`mask_inconsistent`), the packet is corrupt or the decoder is desynchronized. When detected while synced: restore state, lose sync, output `0x01`. When detected while not synced: expected behavior — keep state (full mask is correct) but still output `0x01`.
+When `ft=1`, compare the delta-updated mask with the full mask received. If they differ (`mask_inconsistent`), the packet is corrupt or the decoder is desynchronized. When detected while synced: restore state, lose sync, output `0x01`. When detected while not synced: UAB/CNES expected behavior is to keep state (full mask is correct) but still output `0x01`.
 
 **4. COUNT(F) validation:**
 For `rt=1` packets, the self-delimiting `COUNT(F)` field encodes the packet length. If `COUNT(F)` doesn't match the expected `F`, the packet bitstream is corrupt (wrong bit offset for `I_t` data). Flag as diagnostic (`count_f_mismatch`) and let the harness decide whether to accept or reject.
 
 **5. Robustness window for non-reference packets (rt=0):**
-Non-reference packets are only guaranteed if the preceding `Vt` received packets were all successful (`0x00`). Skip lost packets (`0x02`) in the window since the robustness guarantee applies to decoded packets only.
+Non-reference packets are treated as guaranteed by the UAB/CNES expected outputs only if the preceding `Vt` received packets were all successful (`0x00`). Skip lost packets (`0x02`) in the window since the robustness guarantee applies to decoded packets only.
 
 **6. State management on failure:**
 On decompression failure or unguaranteed status: restore the decompressor state from a saved copy to prevent error propagation to subsequent packets.


### PR DESCRIPTION
## Summary
- Reframe UAB/CNES cross-validation as a CCSDS 124.0-B-1 compatibility test bench rather than a normative conformance source.
- Clarify that the encoder path passes 7,935 / 7,935 vectors while decoder mismatches are UAB/CNES malformed-input compatibility gaps.
- Align CONFORMANCE, GOTCHAS, crossvalidation docs, known-failures comments, README, and AGENTS guidance.

## Verification
- `git diff --check`

Closes #132