### PR TITLE
test: add pairwise interoperability runner (#48)

### DIFF
--- a/crossvalidation/README.md
+++ b/crossvalidation/README.md
@@ -10,6 +10,7 @@ crossvalidation/
   file_list.csv             # Canonical manifest (expected sizes + SHA-256 hashes)
   known-failures.txt        # Documented UAB/CNES compatibility-gap baseline (1,863 decoder vectors)
   run_crossvalidation.sh    # Shared runner script (parameterized for binary paths)
+  interoperability/         # Pairwise interoperability runner (#48)
   c/                        # C implementation harness
   cpp/                      # C++ implementation harness (TODO: #93)
   go/                       # Go implementation harness (TODO: #93)
@@ -17,6 +18,11 @@ crossvalidation/
   java/                     # Java implementation harness (TODO: #93)
   sandbox/                  # Original ESA reference code harness
 ```
+
+[`interoperability/`](interoperability/README.md) answers a different question
+from `run_crossvalidation.sh`: instead of validating one implementation against
+the UAB/CNES expected output, it compares two implementations against each other
+on the same inputs, over separate processes.
 
 Harnesses for the other languages are tracked in [#93](https://github.com/tanagraspace/ccsds124/issues/93) — deliberately deferred until the C UAB/CNES compatibility ruleset is finalized ([#89](https://github.com/tanagraspace/ccsds124/issues/89)), with decoder bitstream hardening ([#92](https://github.com/tanagraspace/ccsds124/issues/92)) as a prerequisite.
 

--- a/crossvalidation/interoperability/README.md
+++ b/crossvalidation/interoperability/README.md
@@ -1,0 +1,158 @@
+# Pairwise interoperability runner
+
+Compares two CCSDS 124.0-B-1 implementations against each other on the same
+inputs, running each one as a separate process.
+
+This is the correctness and interoperability part of
+[#48](https://github.com/tanagraspace/ccsds124/issues/48). Performance, memory
+use and binary-size comparisons remain out of scope for this change.
+
+## How it differs from `run_crossvalidation.sh`
+
+| | `../run_crossvalidation.sh` | this runner |
+|---|---|---|
+| Question | does one implementation match the UAB/CNES expected output? | do two implementations agree with each other? |
+| Inputs | the UAB/CNES suite (not distributed with the repository) | any files you supply |
+| Reference | `file_list.csv` sizes and SHA-256 | the other implementation |
+| Binaries | `ENCODER_BIN` and `DECODER_BIN` | any number of executables declared in a config file |
+
+They answer different questions and neither replaces the other. `make test` and
+`scripts/benchmark.sh` only exercise the implementations in this repository, so
+neither says anything about an external encoder and our decoder.
+
+The runner does not build or download external implementations, and contains no
+third-party source code, headers, libraries or binaries. External executables are
+supplied independently by the user and remain subject to their respective licence
+terms.
+
+## The five results
+
+For each unique pair (X, Y); both cross-decoding directions are evaluated.
+
+| | Property | What a failure means |
+|---|---|---|
+| **A** | X compress → X decompress → original | X is not self-consistent |
+| **B** | Y compress → Y decompress → original | Y is not self-consistent |
+| **C** | X compress → **Y** decompress → original | Y cannot read X's stream |
+| **D** | Y compress → **X** decompress → original | X cannot read Y's stream |
+| **E** | X's compressed stream is byte-identical to Y's | the encoders disagree on the bitstream |
+
+**Bit-identity is not interoperability.** C and D can pass while E fails, when
+both sides make different but legal encoding choices — a success, not a defect.
+E can pass while B or C fails, which narrows the disagreement to decoding rather
+than to the encoded format, without identifying the cause on its own.
+
+A failing cell shows that a pair disagrees, not which side is at fault. A and B
+help narrow it down: if X round-trips its own output and Y does not round-trip
+its own, the evidence points at Y.
+
+`E_bit_identical` has three states:
+
+- `true` — both streams were produced and are identical
+- `false` — both were produced and differ; `E_first_difference` locates the first
+  differing byte and bit
+- `null` — the comparison could not be made, because at least one stream was
+  never produced; `E_detail` says which
+
+## Executable contract
+
+Every declared executable must accept:
+
+```
+<exe> compress   --in FILE --out FILE --json FILE --packet-bytes N --R n --pt n --ft n --rt n
+<exe> decompress --in FILE --out FILE --json FILE --packet-bytes N --R n
+```
+
+It writes its payload to `--out`, a JSON object to `--json`, and exits 0 on
+success. `impl`, `mode`, `rc`, `input_bytes` and `output_bytes` are mandatory;
+`error` is optional; anything else is ignored. Full contract:
+[`schemas/result.schema.json`](schemas/result.schema.json).
+
+**Two distinct status codes.** The process exit code and the `rc` the
+implementation declares in its JSON are recorded separately, as
+`*_process_exit_code` and `*_implementation_rc`. An invocation counts as
+successful only when both are 0, the JSON satisfies the contract, the output file
+exists, and the declared `mode`, `input_bytes` and `output_bytes` match what is
+on disk. A non-zero exit with `rc: 0` is reported as an inconsistency.
+
+`impl` is the identifier the wrapper declares for itself. It is recorded as
+`*_reported_impl` and never compared against the configured alias.
+
+## Usage
+
+Declare the executables. Start from
+[`examples/implementations.example.json`](examples/implementations.example.json)
+and keep your copy out of version control, since the paths are site-specific:
+
+```json
+{
+  "implementations": [
+    {"name": "tanagra-c", "executable": "/path/to/tanagra_harness"},
+    {"name": "external-impl", "executable": "/path/to/external_harness", "timeout": 300}
+  ]
+}
+```
+
+List the cases. `input` is a raw file of concatenated fixed-length packets with no
+header, and `pt`/`ft`/`rt` must match the parameters the vector was produced with,
+since they change the bitstream:
+
+```json
+[
+  {"name": "simple", "input": "../../test-vectors/input/simple.bin",
+   "packet_bytes": 90, "R": 1, "pt": 10, "ft": 20, "rt": 50}
+]
+```
+
+Case names and implementation aliases become directory names under `--workdir`
+(`<case>/<encoder>/<decoder>/`), so they must match
+`^[A-Za-z0-9][A-Za-z0-9_.-]*$`. Relative paths inside the two files resolve
+against the files themselves, not against the current directory.
+
+```bash
+python3 crossvalidation/interoperability/run_correctness.py \
+    --config   my-implementations.json \
+    --cases    my-cases.json \
+    --workdir  /tmp/ccsds124-interop \
+    --out-json results/interop.json \
+    --out-csv  results/interop.csv
+```
+
+Exit status: `0` all checks passed, `1` a reconstruction was incorrect or an
+executable failed, `2` configuration or usage error. `E` alone being false is not
+an error. Stale artefacts from a previous run are deleted before each invocation,
+so a run that produces nothing cannot inherit an earlier result.
+
+## Results
+
+`--out-json` holds one object per case and pair, with the parameters, the SHA-256
+of every artefact, both status codes per implementation, and the five results.
+`--out-csv` writes the same rows flat, nested objects as JSON text.
+
+## Requirements
+
+Python 3.10 or newer, standard library only. The result contract is checked
+directly in `run_correctness.py`, so no JSON-schema library is needed; a test
+keeps the schema file and the in-code checks in step.
+
+## Limits
+
+- Whole-stream comparison. The first differing byte and bit are reported, but the
+  bitstream is not decoded to explain a difference.
+- One packet geometry per case; results do not generalise across `F`.
+- Results depend on the version and build of the external implementation. Record
+  its exact revision alongside any result.
+- Reconstructions are compared exactly. The compressed stream may be byte-padded;
+  the decompressed output may not differ from the input by a single byte.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s crossvalidation/interoperability/tests -v
+```
+
+The suite generates deterministic fake implementations at runtime, so it needs no
+external binary and no network. It covers the five results and their three E
+states, stale-artefact reuse, both status codes, JSON that disagrees with what is
+on disk, configuration and case validation, unsafe names, timeouts, and paths
+containing spaces.

--- a/crossvalidation/interoperability/examples/implementations.example.json
+++ b/crossvalidation/interoperability/examples/implementations.example.json
@@ -1,0 +1,24 @@
+{
+  "_comment": [
+    "Declare two or more external executables to compare. Every unique pair is",
+    "evaluated, with both cross-decoding directions tested. Paths are",
+    "site-specific: copy this file, edit the paths, and keep your copy out of",
+    "version control.",
+    "",
+    "Each executable must honour the CLI/JSON contract in",
+    "schemas/result.schema.json. This repository neither builds nor ships any",
+    "external implementation; you provide the binaries."
+  ],
+  "implementations": [
+    {
+      "name": "tanagra-c",
+      "executable": "/absolute/path/to/tanagra_harness"
+    },
+    {
+      "name": "external-impl",
+      "executable": "/absolute/path/to/external_harness",
+      "extra_args": [],
+      "timeout": 300
+    }
+  ]
+}

--- a/crossvalidation/interoperability/run_correctness.py
+++ b/crossvalidation/interoperability/run_correctness.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""Pairwise interoperability runner for CCSDS 124.0-B-1 implementations.
+
+Drives external executables declared in a configuration file, as separate
+processes, and compares their compressed streams and reconstructions. It holds no
+knowledge of any particular implementation and does not build or download them.
+
+Complements run_crossvalidation.sh: that script validates one pair of harness
+binaries against the UAB/CNES suite, this one compares two implementations
+against each other on the same inputs. See README.md.
+
+Executable contract: schemas/result.schema.json
+
+Exit status:
+  0  every check passed
+  1  a reconstruction was incorrect, or an executable failed
+  2  configuration or usage error
+"""
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+# The result contract. Checked here rather than through `jsonschema` to keep the
+# runner dependency-free; a test asserts this table matches the schema file.
+REQUIRED_RESULT_FIELDS = {
+    "impl": str,
+    "mode": str,
+    "rc": int,
+    "input_bytes": int,
+    "output_bytes": int,
+}
+
+VALID_MODES = ("compress", "decompress")
+
+# Names end up in artefact filenames, so they must not escape the work directory.
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+MIN_ROBUSTNESS = 0
+MAX_ROBUSTNESS = 7
+
+READ_CHUNK_BYTES = 1024 * 1024
+
+DEFAULT_TIMEOUT_SECONDS = 300
+
+
+class ConfigurationError(Exception):
+    """Raised for any invalid configuration or test case. Reported as exit 2."""
+
+
+def is_plain_integer(value):
+    """True for a real integer. Booleans are rejected: bool subclasses int."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def require_non_empty_string(value, description):
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigurationError(f"{description} must be a non-empty string")
+    return value
+
+
+def require_positive_integer(value, description):
+    if not is_plain_integer(value) or value <= 0:
+        raise ConfigurationError(f"{description} must be a positive integer")
+    return value
+
+
+def require_safe_name(value, description):
+    require_non_empty_string(value, description)
+    if not SAFE_NAME.match(value):
+        raise ConfigurationError(
+            f"{description} {value!r} is not a safe name; allowed pattern is "
+            f"{SAFE_NAME.pattern}")
+    return value
+
+
+def validate_result_contract(payload, implementation_name):
+    """Return a list of human-readable contract violations, empty when valid."""
+    if not isinstance(payload, dict):
+        return [f"{implementation_name}: JSON root is {type(payload).__name__}, "
+                f"expected an object"]
+
+    problems = []
+    for field_name, expected_type in REQUIRED_RESULT_FIELDS.items():
+        if field_name not in payload:
+            problems.append(f"{implementation_name}: missing required field "
+                            f"'{field_name}'")
+            continue
+
+        value = payload[field_name]
+        actual_type = type(value).__name__
+        if expected_type is int and not is_plain_integer(value):
+            problems.append(f"{implementation_name}: field '{field_name}' must be "
+                            f"an integer, got {actual_type}")
+        elif expected_type is str and not isinstance(value, str):
+            problems.append(f"{implementation_name}: field '{field_name}' must be "
+                            f"a string, got {actual_type}")
+
+    mode = payload.get("mode")
+    if isinstance(mode, str) and mode not in VALID_MODES:
+        problems.append(f"{implementation_name}: mode '{mode}' is not one of "
+                        f"{VALID_MODES}")
+
+    impl = payload.get("impl")
+    if isinstance(impl, str) and not impl.strip():
+        problems.append(f"{implementation_name}: field 'impl' must not be empty")
+
+    for field_name in ("input_bytes", "output_bytes"):
+        value = payload.get(field_name)
+        if is_plain_integer(value) and value < 0:
+            problems.append(f"{implementation_name}: field '{field_name}' must be "
+                            f">= 0, got {value}")
+
+    # 'error' is optional, but when present it must be a string: converting an
+    # object or a number to text here would hide a contract violation.
+    if "error" in payload and not isinstance(payload["error"], str):
+        problems.append(f"{implementation_name}: field 'error' must be a string, "
+                        f"got {type(payload['error']).__name__}")
+
+    return problems
+
+
+def sha256_file(path):
+    """Return the SHA-256 hex digest of a file, or None if it cannot be read."""
+    if not path or not os.path.isfile(path):
+        return None
+
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            while chunk := handle.read(READ_CHUNK_BYTES):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def file_size(path):
+    """Return the size of a file in bytes, or None if it cannot be read."""
+    if not path:
+        return None
+    try:
+        if not os.path.isfile(path):
+            return None
+        return os.path.getsize(path)
+    except OSError:
+        return None
+
+
+def remove_previous_artifact(path):
+    """Delete a leftover artefact so a failed run cannot reuse an older one."""
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        raise ConfigurationError(f"cannot remove stale artefact {path}: {error}")
+
+
+def files_are_identical(first_path, second_path):
+    """Compare two files byte by byte, in chunks.
+
+    Returns (identical, difference). `difference` locates the first divergence,
+    with `value_a`/`value_b` set to None on whichever side ended first.
+    """
+    offset = 0
+    with open(first_path, "rb") as first, open(second_path, "rb") as second:
+        while True:
+            first_chunk = first.read(READ_CHUNK_BYTES)
+            second_chunk = second.read(READ_CHUNK_BYTES)
+            if not first_chunk and not second_chunk:
+                return True, None
+
+            for index, (first_byte, second_byte) in enumerate(
+                    zip(first_chunk, second_chunk)):
+                if first_byte != second_byte:
+                    byte_index = offset + index
+                    bit_in_byte = 8 - (first_byte ^ second_byte).bit_length()
+                    return False, {
+                        "byte": byte_index,
+                        "bit": byte_index * 8 + bit_in_byte,
+                        "value_a": first_byte,
+                        "value_b": second_byte,
+                    }
+
+            if len(first_chunk) != len(second_chunk):
+                shorter = min(len(first_chunk), len(second_chunk))
+                byte_index = offset + shorter
+                first_value = first_chunk[shorter] if shorter < len(first_chunk) else None
+                second_value = second_chunk[shorter] if shorter < len(second_chunk) else None
+                return False, {
+                    "byte": byte_index,
+                    "bit": byte_index * 8,
+                    "value_a": first_value,
+                    "value_b": second_value,
+                }
+
+            offset += len(first_chunk)
+
+
+def compare_streams(first_path, second_path):
+    """Compare two compressed streams.
+
+    Returns (identical, difference, detail). `identical` is None when the
+    comparison could not be made at all, and `detail` then says why.
+    """
+    for path in (first_path, second_path):
+        if not os.path.isfile(path):
+            return None, None, f"stream not produced: {os.path.basename(path)}"
+
+    try:
+        identical, difference = files_are_identical(first_path, second_path)
+    except OSError as error:
+        return None, None, f"cannot read stream: {error}"
+    return identical, difference, "" if identical else "streams differ"
+
+
+def reconstruction_matches(original_path, produced_path):
+    """Check that a decompressed file reproduces the original exactly.
+
+    Returns (matches, detail). No trailing bytes are tolerated: the compressed
+    stream may be byte-padded, the reconstruction may not.
+    """
+    if not os.path.isfile(produced_path):
+        return False, f"no output produced: {os.path.basename(produced_path)}"
+
+    original_size = file_size(original_path)
+    produced_size = file_size(produced_path)
+    if produced_size != original_size:
+        return False, f"output size {produced_size} != input size {original_size}"
+
+    try:
+        identical, difference = files_are_identical(original_path, produced_path)
+    except OSError as error:
+        return False, f"cannot read output: {error}"
+    if not identical:
+        return False, f"payload differs from original at byte {difference['byte']}"
+    return True, ""
+
+
+class ExecutionOutcome:
+    """The result of invoking one external executable once.
+
+    The process exit code and the `rc` the implementation declares in its JSON
+    are two different things; both are kept.
+    """
+
+    def __init__(self, succeeded, process_exit_code, implementation_rc,
+                 error_message, result_payload):
+        self.succeeded = succeeded
+        self.process_exit_code = process_exit_code
+        self.implementation_rc = implementation_rc
+        self.error_message = error_message
+        self.result_payload = result_payload
+
+    @property
+    def reported_impl(self):
+        """The identifier the wrapper declared. Informational, never checked."""
+        return self.result_payload.get("impl")
+
+
+class RoundTripCheck:
+    """Outcome of decompressing one stream and comparing it to the original."""
+
+    def __init__(self, reconstructed_ok, detail, output_sha256):
+        self.reconstructed_ok = reconstructed_ok
+        self.detail = detail
+        self.output_sha256 = output_sha256
+
+
+class Implementation:
+    """One external executable honouring the documented CLI/JSON contract."""
+
+    def __init__(self, spec, default_timeout, config_dir=""):
+        if not isinstance(spec, dict):
+            raise ConfigurationError(
+                f"implementation entry must be an object, got {type(spec).__name__}")
+
+        for required_key in ("name", "executable"):
+            if required_key not in spec:
+                raise ConfigurationError(
+                    f"implementation entry is missing '{required_key}'")
+
+        self.name = require_safe_name(spec["name"], "implementation name")
+        executable = require_non_empty_string(
+            spec["executable"], f"implementation {self.name!r} 'executable'")
+
+        # Relative paths resolve against the configuration file, not the CWD.
+        if os.path.isabs(executable):
+            self.executable = executable
+        else:
+            self.executable = os.path.normpath(os.path.join(config_dir, executable))
+
+        extra_args = spec.get("extra_args", [])
+        if not isinstance(extra_args, list):
+            raise ConfigurationError(
+                f"implementation {self.name!r} 'extra_args' must be a list")
+        for argument in extra_args:
+            if not isinstance(argument, str):
+                raise ConfigurationError(
+                    f"implementation {self.name!r} 'extra_args' must contain only "
+                    f"strings, got {type(argument).__name__}")
+        self.extra_args = list(extra_args)
+
+        self.timeout = require_positive_integer(
+            spec.get("timeout", default_timeout),
+            f"implementation {self.name!r} 'timeout'")
+
+    def build_command(self, mode, input_path, output_path, result_json_path,
+                      packet_bytes, robustness, pt=None, ft=None, rt=None):
+        """Assemble the argument list for one invocation."""
+        command = [
+            self.executable, mode,
+            "--in", input_path,
+            "--out", output_path,
+            "--json", result_json_path,
+            "--packet-bytes", str(packet_bytes),
+            "--R", str(robustness),
+        ]
+        if mode == "compress":
+            command += ["--pt", str(pt), "--ft", str(ft), "--rt", str(rt)]
+        return command + self.extra_args
+
+    def invoke_process(self, command):
+        """Run one command. Returns (completed_process, launch_error)."""
+        try:
+            completed = subprocess.run(command, capture_output=True,
+                                       timeout=self.timeout)
+        except FileNotFoundError:
+            return None, f"executable not found: {self.executable}"
+        except PermissionError:
+            return None, f"executable not runnable: {self.executable}"
+        except subprocess.TimeoutExpired:
+            return None, f"timeout after {self.timeout}s"
+        return completed, None
+
+    def load_result_json(self, result_json_path):
+        """Read and contract-check the JSON produced. Returns (payload, error)."""
+        try:
+            with open(result_json_path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, UnicodeDecodeError) as error:
+            return {}, f"cannot read JSON from {self.name}: {error}"
+        except json.JSONDecodeError as error:
+            return {}, f"invalid JSON from {self.name}: {error}"
+
+        problems = validate_result_contract(payload, self.name)
+        if problems:
+            reported = payload if isinstance(payload, dict) else {}
+            return reported, "contract violation: " + "; ".join(problems)
+
+        return payload, None
+
+    def check_against_invocation(self, payload, mode, input_path, output_path):
+        """Check the declared JSON against what actually happened on disk."""
+        if payload["mode"] != mode:
+            return f"declared mode '{payload['mode']}' but was invoked as '{mode}'"
+
+        actual_input = file_size(input_path)
+        if payload["input_bytes"] != actual_input:
+            return (f"declared input_bytes {payload['input_bytes']} but "
+                    f"{os.path.basename(input_path)} is {actual_input} bytes")
+
+        if not os.path.isfile(output_path):
+            return f"no output written to {os.path.basename(output_path)}"
+
+        actual_output = file_size(output_path)
+        if payload["output_bytes"] != actual_output:
+            return (f"declared output_bytes {payload['output_bytes']} but "
+                    f"{os.path.basename(output_path)} is {actual_output} bytes")
+
+        return None
+
+    def run(self, mode, input_path, output_path, result_json_path,
+            packet_bytes, robustness, pt=None, ft=None, rt=None):
+        """Invoke the executable once and return an ExecutionOutcome."""
+        # A run that produces nothing must not be able to reuse older artefacts.
+        remove_previous_artifact(output_path)
+        remove_previous_artifact(result_json_path)
+
+        command = self.build_command(mode, input_path, output_path,
+                                     result_json_path, packet_bytes, robustness,
+                                     pt, ft, rt)
+
+        completed, launch_error = self.invoke_process(command)
+        if launch_error:
+            return ExecutionOutcome(False, None, None, launch_error, {})
+
+        exit_code = completed.returncode
+        stdout = completed.stdout.decode("utf-8", errors="replace").strip()
+        stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+
+        if not os.path.isfile(result_json_path):
+            message = f"{self.name} produced no JSON at {result_json_path}"
+            if stdout:
+                message += f" (stdout: {stdout[:200]})"
+            return ExecutionOutcome(False, exit_code, None, message, {})
+
+        payload, json_error = self.load_result_json(result_json_path)
+        if json_error:
+            return ExecutionOutcome(False, exit_code, payload.get("rc"),
+                                    json_error, payload)
+
+        implementation_rc = payload["rc"]
+        declared_error = payload.get("error", "")
+
+        if exit_code != 0 and implementation_rc == 0:
+            return ExecutionOutcome(
+                False, exit_code, implementation_rc,
+                f"inconsistent status: process exited {exit_code} but declared rc=0",
+                payload)
+
+        if exit_code != 0 or implementation_rc != 0:
+            message = stderr or declared_error or (
+                f"process exit {exit_code}, rc {implementation_rc}")
+            return ExecutionOutcome(False, exit_code, implementation_rc,
+                                    message, payload)
+
+        mismatch = self.check_against_invocation(payload, mode, input_path,
+                                                 output_path)
+        if mismatch:
+            return ExecutionOutcome(False, exit_code, implementation_rc,
+                                    mismatch, payload)
+
+        return ExecutionOutcome(True, exit_code, implementation_rc,
+                                stderr or declared_error, payload)
+
+
+def pair_directory(workdir, case, encoder, decoder):
+    """Create and return the directory holding one case-and-pair's artefacts.
+
+    The three names are nested rather than concatenated: joining them into a
+    single tag could produce the same string for two different pairs, for
+    instance ("a-vs-b", "c") and ("a", "b-vs-c"). All three are already
+    constrained by SAFE_NAME, so the path stays inside workdir.
+    """
+    path = os.path.join(workdir, case["name"], encoder.name, decoder.name)
+    try:
+        os.makedirs(path, exist_ok=True)
+    except OSError as error:
+        raise ConfigurationError(f"cannot create work directory {path}: {error}")
+    return path
+
+
+def compress_with(implementation, case, pair_dir, prefix):
+    """Compress the case input. Returns (stream_path, outcome)."""
+    stream_path = os.path.join(pair_dir, prefix + ".cmp")
+    outcome = implementation.run(
+        "compress", case["input"], stream_path,
+        os.path.join(pair_dir, prefix + ".json"),
+        case["packet_bytes"], case["R"], case["pt"], case["ft"], case["rt"],
+    )
+    return stream_path, outcome
+
+
+def check_round_trip(implementation, compression_succeeded, compressed_path,
+                     case, pair_dir, label):
+    """Decompress one stream and check it reproduces the case input."""
+    if not compression_succeeded:
+        return RoundTripCheck(False, "upstream compress failed", None)
+
+    decompressed_path = os.path.join(pair_dir, label + ".out")
+    outcome = implementation.run(
+        "decompress", compressed_path, decompressed_path,
+        os.path.join(pair_dir, label + ".json"),
+        case["packet_bytes"], case["R"],
+    )
+    if not outcome.succeeded:
+        return RoundTripCheck(False, outcome.error_message, None)
+
+    matches, detail = reconstruction_matches(case["input"], decompressed_path)
+    return RoundTripCheck(matches, detail, sha256_file(decompressed_path))
+
+
+def build_result_row(case, encoder, decoder, encoder_compression,
+                     decoder_compression, encoder_stream, decoder_stream,
+                     stream_comparison, round_trips):
+    """Assemble one public result record."""
+    identical, difference, comparison_detail = stream_comparison
+
+    row = {
+        "case": case["name"],
+        "encoder": encoder.name,
+        "decoder": decoder.name,
+        "packet_bytes": case["packet_bytes"],
+        "F_bits": case["packet_bytes"] * 8,
+        "R": case["R"],
+        "pt": case["pt"],
+        "ft": case["ft"],
+        "rt": case["rt"],
+        "input_sha256": sha256_file(case["input"]),
+        "input_bytes": file_size(case["input"]),
+        "encoder_process_exit_code": encoder_compression.process_exit_code,
+        "encoder_implementation_rc": encoder_compression.implementation_rc,
+        "encoder_reported_impl": encoder_compression.reported_impl,
+        "encoder_compress_error": encoder_compression.error_message,
+        "encoder_compressed_bytes": file_size(encoder_stream),
+        "encoder_compressed_sha256": sha256_file(encoder_stream),
+        "decoder_process_exit_code": decoder_compression.process_exit_code,
+        "decoder_implementation_rc": decoder_compression.implementation_rc,
+        "decoder_reported_impl": decoder_compression.reported_impl,
+        "decoder_compress_error": decoder_compression.error_message,
+        "decoder_compressed_bytes": file_size(decoder_stream),
+        "decoder_compressed_sha256": sha256_file(decoder_stream),
+        "E_bit_identical": identical,
+        "E_detail": comparison_detail,
+        "E_first_difference": difference,
+    }
+
+    for letter, result_key, check in round_trips:
+        row[result_key] = check.reconstructed_ok
+        row[f"{letter}_detail"] = check.detail
+        row[f"{letter}_output_sha256"] = check.output_sha256
+
+    return row
+
+
+def run_pair(encoder, decoder, case, workdir, results):
+    """Evaluate one unique pair of implementations for one case.
+
+    Both cross-decoding directions are evaluated. Appends one record to
+    `results` and returns True when every reconstruction check passed;
+    bit-identity alone does not affect the returned value.
+    """
+    pair_dir = pair_directory(workdir, case, encoder, decoder)
+
+    encoder_stream, encoder_compression = compress_with(
+        encoder, case, pair_dir, "encoder")
+    decoder_stream, decoder_compression = compress_with(
+        decoder, case, pair_dir, "decoder")
+
+    round_trips = [
+        # A: the encoder reads back its own stream.
+        ("A", "A_encoder_roundtrip", check_round_trip(
+            encoder, encoder_compression.succeeded, encoder_stream,
+            case, pair_dir, "A")),
+        # B: the decoder reads back its own stream.
+        ("B", "B_decoder_roundtrip", check_round_trip(
+            decoder, decoder_compression.succeeded, decoder_stream,
+            case, pair_dir, "B")),
+        # C: the decoder reads the encoder's stream.
+        ("C", "C_encoder_to_decoder", check_round_trip(
+            decoder, encoder_compression.succeeded, encoder_stream,
+            case, pair_dir, "C")),
+        # D: the encoder reads the decoder's stream.
+        ("D", "D_decoder_to_encoder", check_round_trip(
+            encoder, decoder_compression.succeeded, decoder_stream,
+            case, pair_dir, "D")),
+    ]
+
+    # E: are both compressed streams byte-for-byte identical?
+    stream_comparison = compare_streams(encoder_stream, decoder_stream)
+
+    results.append(build_result_row(
+        case, encoder, decoder, encoder_compression, decoder_compression,
+        encoder_stream, decoder_stream, stream_comparison, round_trips))
+
+    return all(check.reconstructed_ok for _, _, check in round_trips)
+
+
+def load_json_file(path, description):
+    """Read and parse a JSON file, reporting failures as configuration errors."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, UnicodeDecodeError) as error:
+        raise ConfigurationError(f"cannot read {description}: {error}")
+    except json.JSONDecodeError as error:
+        raise ConfigurationError(f"invalid JSON in {description}: {error}")
+
+
+def build_implementations(config, default_timeout, config_dir):
+    """Validate the configuration and build the Implementation objects."""
+    if not isinstance(config, dict):
+        raise ConfigurationError(
+            f"configuration root must be an object, got {type(config).__name__}")
+
+    declared = config.get("implementations")
+    if not isinstance(declared, list):
+        raise ConfigurationError("configuration 'implementations' must be a list")
+
+    implementations = [
+        Implementation(spec, default_timeout, config_dir) for spec in declared
+    ]
+    if len(implementations) < 2:
+        raise ConfigurationError("at least two implementations are required")
+
+    # Names index the artefact filenames, so duplicates would make two
+    # implementations overwrite each other's results.
+    seen_names = set()
+    duplicate_names = set()
+    for implementation in implementations:
+        if implementation.name in seen_names:
+            duplicate_names.add(implementation.name)
+        else:
+            seen_names.add(implementation.name)
+
+    if duplicate_names:
+        raise ConfigurationError("implementation names must be unique: "
+                                 + ", ".join(sorted(duplicate_names)))
+
+    return implementations
+
+
+def validate_case(case, cases_dir):
+    """Validate one test case and return it with its input path resolved."""
+    if not isinstance(case, dict):
+        raise ConfigurationError(f"case must be an object, got {type(case).__name__}")
+
+    name = require_safe_name(case.get("name"), "case name")
+    declared_input = require_non_empty_string(case.get("input"),
+                                              f"case {name!r} 'input'")
+    packet_bytes = require_positive_integer(case.get("packet_bytes"),
+                                            f"case {name!r} 'packet_bytes'")
+
+    robustness = case.get("R")
+    if not is_plain_integer(robustness) or not (
+            MIN_ROBUSTNESS <= robustness <= MAX_ROBUSTNESS):
+        raise ConfigurationError(f"case {name!r} 'R' must be an integer in "
+                                 f"[{MIN_ROBUSTNESS}, {MAX_ROBUSTNESS}]")
+
+    # The standard fixes no range for the pt/ft/rt countdown periods, so only
+    # the type is checked here.
+    for field_name in ("pt", "ft", "rt"):
+        if not is_plain_integer(case.get(field_name)):
+            raise ConfigurationError(f"case {name!r} '{field_name}' must be an integer")
+
+    # Relative paths resolve against the cases file, not the CWD.
+    input_path = declared_input
+    if not os.path.isabs(input_path):
+        input_path = os.path.normpath(os.path.join(cases_dir, input_path))
+
+    if not os.path.exists(input_path):
+        raise ConfigurationError(f"case {name!r} input not found: {input_path}")
+    if not os.path.isfile(input_path):
+        raise ConfigurationError(f"case {name!r} input is not a regular file: "
+                                 f"{input_path}")
+
+    size = os.path.getsize(input_path)
+    if size == 0 or size % packet_bytes != 0:
+        raise ConfigurationError(
+            f"case {name!r} input is {size} bytes, not a non-zero multiple of "
+            f"packet_bytes={packet_bytes}")
+
+    resolved = dict(case)
+    resolved["input"] = input_path
+    return resolved
+
+
+def validate_cases(cases, cases_dir):
+    """Validate the whole cases file, preserving file order."""
+    if not isinstance(cases, list):
+        raise ConfigurationError(f"cases file must be a list, got "
+                                 f"{type(cases).__name__}")
+    if not cases:
+        raise ConfigurationError("cases file is empty")
+
+    validated = []
+    seen_names = set()
+    for case in cases:
+        resolved = validate_case(case, cases_dir)
+        if resolved["name"] in seen_names:
+            raise ConfigurationError(f"duplicate case name: {resolved['name']}")
+        seen_names.add(resolved["name"])
+        validated.append(resolved)
+
+    return validated
+
+
+def write_json_results(path, results):
+    """Write every result record as one JSON array."""
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(results, handle, indent=2, sort_keys=True)
+    except OSError as error:
+        raise ConfigurationError(f"cannot write {path}: {error}")
+
+
+def write_csv_results(path, results):
+    """Write every result record as one CSV table, nested objects as JSON text."""
+    if not results:
+        return
+
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(results[0].keys()))
+            writer.writeheader()
+            for row in results:
+                writer.writerow({
+                    key: json.dumps(value) if isinstance(value, dict) else value
+                    for key, value in row.items()
+                })
+    except OSError as error:
+        raise ConfigurationError(f"cannot write {path}: {error}")
+
+
+def parse_arguments(argv):
+    """Define and parse the command line."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--config", required=True,
+                        help="JSON file declaring the external executables")
+    parser.add_argument("--cases", required=True,
+                        help="JSON file declaring the test cases")
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--out-json", required=True)
+    parser.add_argument("--out-csv")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    arguments = parse_arguments(argv)
+
+    try:
+        require_positive_integer(arguments.timeout, "--timeout")
+        config = load_json_file(arguments.config, "configuration file")
+        cases_document = load_json_file(arguments.cases, "cases file")
+
+        implementations = build_implementations(
+            config, arguments.timeout,
+            os.path.dirname(os.path.abspath(arguments.config)))
+        cases = validate_cases(
+            cases_document, os.path.dirname(os.path.abspath(arguments.cases)))
+    except ConfigurationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    workdir = os.path.abspath(arguments.workdir)
+    try:
+        os.makedirs(workdir, exist_ok=True)
+    except OSError as error:
+        print(f"error: cannot create workdir {workdir}: {error}", file=sys.stderr)
+        return 2
+
+    results = []
+    every_check_passed = True
+
+    for case in cases:
+        # Each unique pair once; C and D cover both cross-decoding directions.
+        for encoder_index, encoder in enumerate(implementations):
+            for decoder in implementations[encoder_index + 1:]:
+                try:
+                    passed = run_pair(encoder, decoder, case, workdir, results)
+                except ConfigurationError as error:
+                    print(f"error: {error}", file=sys.stderr)
+                    return 2
+                if not passed:
+                    every_check_passed = False
+
+                row = results[-1]
+                print(f"{case['name']:24s} {encoder.name} vs {decoder.name}: "
+                      f"A={row['A_encoder_roundtrip']} "
+                      f"B={row['B_decoder_roundtrip']} "
+                      f"C={row['C_encoder_to_decoder']} "
+                      f"D={row['D_decoder_to_encoder']} "
+                      f"E={row['E_bit_identical']}")
+
+    try:
+        write_json_results(arguments.out_json, results)
+        if arguments.out_csv:
+            write_csv_results(arguments.out_csv, results)
+    except ConfigurationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(f"\nresults: {arguments.out_json}")
+    return 0 if every_check_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crossvalidation/interoperability/schemas/result.schema.json
+++ b/crossvalidation/interoperability/schemas/result.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tanagraspace/ccsds124/crossvalidation/interoperability/schemas/result.schema.json",
+  "title": "CCSDS 124.0-B-1 interoperability harness result",
+  "description": "Contract an external executable must satisfy to be driven by run_correctness.py. The executable is invoked as:\n  <exe> compress   --in F --out F --json F --packet-bytes N --R n --pt n --ft n --rt n\n  <exe> decompress --in F --out F --json F --packet-bytes N --R n\nIt must write the payload to --out and this JSON object to --json, and exit 0 on success. Only the fields listed here are consumed; anything else is ignored.",
+  "type": "object",
+  "required": [
+    "impl",
+    "mode",
+    "rc",
+    "input_bytes",
+    "output_bytes"
+  ],
+  "properties": {
+    "impl": {
+      "type": "string",
+      "description": "Identifier the wrapper declares for itself. Recorded as reported_impl in the results; never compared against the configured alias.",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "compress",
+        "decompress"
+      ],
+      "description": "Must match the mode the executable was invoked with."
+    },
+    "rc": {
+      "type": "integer",
+      "description": "Implementation-level return code, 0 on success. Distinct from the process exit code; both are recorded and both must be 0 for the invocation to count as successful."
+    },
+    "input_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Size in bytes of the file passed to --in. Must match the file on disk."
+    },
+    "output_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Size in bytes of the payload written to --out. Must match the file on disk."
+    },
+    "error": {
+      "type": "string",
+      "description": "Human-readable error message. Empty or absent on success."
+    }
+  },
+  "additionalProperties": true
+}

--- a/crossvalidation/interoperability/tests/test_run_correctness.py
+++ b/crossvalidation/interoperability/tests/test_run_correctness.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""Tests for the pairwise interoperability runner.
+
+Everything is driven by small deterministic fake implementations generated at
+test time, so the suite needs no external binary, no network, and no CCSDS
+implementation. Run with:
+
+    python3 -m unittest discover -s crossvalidation/interoperability/tests -v
+"""
+import contextlib
+import io
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+RUNNER_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, RUNNER_DIR)
+
+import run_correctness  # noqa: E402
+
+
+FAKE_IMPLEMENTATION_SOURCE = r'''#!/usr/bin/env python3
+"""Deterministic fake implementation used by the runner tests.
+
+Behaviour is selected with the FAKE_MODE environment variable. "Compression" is
+a reversible XOR with the key in FAKE_KEY, so two fakes sharing a key produce
+byte-identical streams, and two fakes with different keys cannot read each
+other's output.
+"""
+import json
+import os
+import sys
+
+
+def write_result(path, payload):
+    with open(path, "w") as handle:
+        json.dump(payload, handle)
+
+
+mode = sys.argv[1]
+arguments = dict(zip(sys.argv[2::2], sys.argv[3::2]))
+behaviour = os.environ.get("FAKE_MODE", "good")
+key = int(os.environ.get("FAKE_KEY", "0"))
+
+if behaviour == "hang":
+    import time
+    time.sleep(30)
+
+with open(arguments["--in"], "rb") as handle:
+    data = handle.read()
+
+base = {"impl": "fake", "mode": mode, "input_bytes": len(data)}
+
+if behaviour == "compress_error" and mode == "compress":
+    write_result(arguments["--json"],
+                 dict(base, rc=7, output_bytes=0, error="synthetic failure"))
+    sys.exit(1)
+
+if behaviour == "bad_json":
+    with open(arguments["--json"], "w") as handle:
+        handle.write("{not valid json")
+    sys.exit(0)
+
+if behaviour == "missing_keys":
+    write_result(arguments["--json"], {"impl": "fake", "mode": mode})
+    sys.exit(0)
+
+if behaviour == "wrong_types":
+    write_result(arguments["--json"], dict(base, rc="zero", output_bytes=-3))
+    sys.exit(0)
+
+if behaviour == "bad_mode":
+    write_result(arguments["--json"],
+                 dict(base, mode="transmogrify", rc=0, output_bytes=0))
+    sys.exit(0)
+
+if behaviour == "bad_error_type":
+    write_result(arguments["--json"],
+                 dict(base, rc=0, output_bytes=0, error={"message": "invalid"}))
+    sys.exit(0)
+
+if behaviour == "empty_impl":
+    write_result(arguments["--json"], dict(base, impl="", rc=0, output_bytes=0))
+    sys.exit(0)
+
+if behaviour == "no_json":
+    sys.exit(0)
+
+if behaviour == "no_output":
+    write_result(arguments["--json"], dict(base, rc=0, output_bytes=0))
+    sys.exit(0)
+
+output = bytes(byte ^ key for byte in data)
+
+if behaviour == "bad_decompress" and mode == "decompress":
+    output = bytes((byte + 1) % 256 for byte in output)
+
+if behaviour == "extra_zero_byte" and mode == "decompress":
+    output = output + b"\x00"
+
+with open(arguments["--out"], "wb") as handle:
+    handle.write(output)
+
+if behaviour == "wrong_input_bytes":
+    write_result(arguments["--json"],
+                 dict(base, rc=0, input_bytes=len(data) + 1,
+                      output_bytes=len(output)))
+    sys.exit(0)
+
+if behaviour == "wrong_output_bytes":
+    write_result(arguments["--json"],
+                 dict(base, rc=0, output_bytes=len(output) + 1))
+    sys.exit(0)
+
+if behaviour == "rc_nonzero_exit_zero":
+    write_result(arguments["--json"],
+                 dict(base, rc=5, output_bytes=len(output), error="declared rc 5"))
+    sys.exit(0)
+
+if behaviour == "exit_nonzero_rc_zero":
+    write_result(arguments["--json"], dict(base, rc=0, output_bytes=len(output)))
+    sys.exit(4)
+
+if behaviour == "both_nonzero":
+    write_result(arguments["--json"],
+                 dict(base, rc=9, output_bytes=len(output), error="both non-zero"))
+    sys.exit(4)
+
+write_result(arguments["--json"], dict(base, rc=0, output_bytes=len(output)))
+'''
+
+
+def write_fake_implementation(path, extra_environment=None):
+    """Write the fake implementation, optionally wrapped to force env vars."""
+    with open(path, "w") as handle:
+        handle.write(FAKE_IMPLEMENTATION_SOURCE)
+    os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def write_env_wrapper(path, target, environment):
+    """Write an executable that runs `target` with extra environment variables."""
+    assignments = "".join(
+        f"os.environ[{key!r}] = {value!r}\n" for key, value in environment.items())
+    with open(path, "w") as handle:
+        handle.write(
+            "#!/usr/bin/env python3\n"
+            "import os, runpy, sys\n"
+            f"{assignments}"
+            f"sys.argv[0] = {target!r}\n"
+            f"runpy.run_path({target!r}, run_name='__main__')\n")
+    os.chmod(path, 0o755)
+
+
+def write_json_file(path, payload):
+    with open(path, "w") as handle:
+        json.dump(payload, handle)
+
+
+def read_json_file(path):
+    with open(path) as handle:
+        return json.load(handle)
+
+
+def build_case(name, input_path, robustness=1, pt=10, ft=20, rt=50,
+               packet_bytes=90):
+    """One test case entry, with the packet geometry the fixtures use."""
+    return {"name": name, "input": input_path, "packet_bytes": packet_bytes,
+            "R": robustness, "pt": pt, "ft": ft, "rt": rt}
+
+
+class TestHelpers(unittest.TestCase):
+    """Direct tests of the comparison helpers, without any subprocess."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="ccsds124-helpers-")
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
+
+    def write_pair(self, first_content, second_content):
+        """Write two files and return their paths."""
+        paths = []
+        for name, content in (("first", first_content), ("second", second_content)):
+            path = os.path.join(self.temp_dir, name)
+            with open(path, "wb") as handle:
+                handle.write(content)
+            paths.append(path)
+        return paths
+
+    def test_reconstruction_exact(self):
+        matches, _ = run_correctness.reconstruction_matches(
+            *self.write_pair(b"hello", b"hello"))
+        self.assertTrue(matches)
+
+    def test_reconstruction_rejects_one_extra_zero_byte(self):
+        matches, detail = run_correctness.reconstruction_matches(
+            *self.write_pair(b"hello", b"hello\x00"))
+        self.assertFalse(matches)
+        self.assertIn("size", detail)
+
+    def test_reconstruction_rejects_short_output(self):
+        matches, detail = run_correctness.reconstruction_matches(
+            *self.write_pair(b"hello", b"hel"))
+        self.assertFalse(matches)
+        self.assertIn("size", detail)
+
+    def test_reconstruction_rejects_missing_output(self):
+        original, _ = self.write_pair(b"hello", b"hello")
+        matches, detail = run_correctness.reconstruction_matches(
+            original, os.path.join(self.temp_dir, "absent"))
+        self.assertFalse(matches)
+        self.assertIn("no output produced", detail)
+
+    def test_streams_identical(self):
+        identical, difference, detail = run_correctness.compare_streams(
+            *self.write_pair(b"abc", b"abc"))
+        self.assertTrue(identical)
+        self.assertIsNone(difference)
+        self.assertEqual(detail, "")
+
+    def test_empty_streams_are_identical(self):
+        identical, difference, _ = run_correctness.compare_streams(
+            *self.write_pair(b"", b""))
+        self.assertTrue(identical)
+        self.assertIsNone(difference)
+
+    def test_difference_on_first_bit(self):
+        _, difference, _ = run_correctness.compare_streams(
+            *self.write_pair(bytes([0x00]), bytes([0x80])))
+        self.assertEqual(difference["byte"], 0)
+        self.assertEqual(difference["bit"], 0)
+        self.assertEqual(difference["value_a"], 0x00)
+        self.assertEqual(difference["value_b"], 0x80)
+
+    def test_difference_in_the_middle(self):
+        _, difference, _ = run_correctness.compare_streams(
+            *self.write_pair(b"abcdef", b"abcXef"))
+        self.assertEqual(difference["byte"], 3)
+        self.assertEqual(difference["value_a"], ord("d"))
+        self.assertEqual(difference["value_b"], ord("X"))
+
+    def test_first_stream_shorter(self):
+        identical, difference, _ = run_correctness.compare_streams(
+            *self.write_pair(b"abc", b"abcd"))
+        self.assertFalse(identical)
+        self.assertEqual(difference["byte"], 3)
+        self.assertIsNone(difference["value_a"])
+        self.assertEqual(difference["value_b"], ord("d"))
+
+    def test_second_stream_shorter(self):
+        identical, difference, _ = run_correctness.compare_streams(
+            *self.write_pair(b"abcd", b"abc"))
+        self.assertFalse(identical)
+        self.assertEqual(difference["value_a"], ord("d"))
+        self.assertIsNone(difference["value_b"])
+
+    def test_comparison_impossible_when_a_stream_is_missing(self):
+        first, _ = self.write_pair(b"abc", b"abc")
+        identical, difference, detail = run_correctness.compare_streams(
+            first, os.path.join(self.temp_dir, "absent"))
+        self.assertIsNone(identical)
+        self.assertIsNone(difference)
+        self.assertIn("not produced", detail)
+
+
+class RunnerTestBase(unittest.TestCase):
+    """Shared fixture: one fake executable, one input file, one case file."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="ccsds124-interop-")
+        self.addCleanup(shutil.rmtree, self.temp_dir, ignore_errors=True)
+
+        self.fake_executable = os.path.join(self.temp_dir, "fake_impl.py")
+        write_fake_implementation(self.fake_executable)
+
+        # 900 bytes: exactly ten packets of 90 bytes.
+        self.input_path = os.path.join(self.temp_dir, "input.bin")
+        with open(self.input_path, "wb") as handle:
+            handle.write(bytes((index * 7 + 3) % 256 for index in range(900)))
+
+        self.cases_path = os.path.join(self.temp_dir, "cases.json")
+        write_json_file(self.cases_path, [build_case("fixture", self.input_path)])
+
+        self.out_json_path = os.path.join(self.temp_dir, "out.json")
+        self.workdir = os.path.join(self.temp_dir, "work")
+
+    def write_config_file(self, entries=None, timeout=None, name="config.json"):
+        """Write a configuration and return its path."""
+        if entries is None:
+            second = {"name": "impl-b", "executable": self.fake_executable}
+            if timeout is not None:
+                second["timeout"] = timeout
+            entries = [{"name": "impl-a", "executable": self.fake_executable}, second]
+
+        config_path = os.path.join(self.temp_dir, name)
+        write_json_file(config_path, {"implementations": entries})
+        return config_path
+
+    def run_runner(self, config_path=None, cases_path=None, environment=None,
+                   workdir=None, extra_args=()):
+        """Run the runner in-process and return (exit_code, stderr, rows)."""
+        argv = [
+            "--config", config_path or self.write_config_file(),
+            "--cases", cases_path or self.cases_path,
+            "--workdir", workdir or self.workdir,
+            "--out-json", self.out_json_path,
+            "--out-csv", os.path.join(self.temp_dir, "out.csv"),
+            *extra_args,
+        ]
+
+        child_environment = dict(os.environ, FAKE_MODE="good")
+        if environment:
+            child_environment.update(environment)
+
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.dict(os.environ, child_environment, clear=True), \
+                contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = run_correctness.main(argv)
+
+        rows = read_json_file(self.out_json_path) if os.path.exists(
+            self.out_json_path) else []
+        return exit_code, stderr.getvalue(), rows
+
+
+class TestNominal(RunnerTestBase):
+    def test_bit_identical_streams(self):
+        exit_code, stderr, rows = self.run_runner()
+        self.assertEqual(exit_code, 0, stderr)
+        self.assertEqual(len(rows), 1)
+
+        row = rows[0]
+        self.assertIs(row["E_bit_identical"], True)
+        self.assertIsNone(row["E_first_difference"])
+        for key in ("A_encoder_roundtrip", "B_decoder_roundtrip",
+                    "C_encoder_to_decoder", "D_decoder_to_encoder"):
+            self.assertTrue(row[key], f"{key} should pass")
+
+    def test_reported_impl_is_recorded_not_checked(self):
+        _, _, rows = self.run_runner()
+        self.assertEqual(rows[0]["encoder_reported_impl"], "fake")
+        self.assertNotEqual(rows[0]["encoder"], rows[0]["encoder_reported_impl"])
+
+    def test_sha256_recorded_for_every_artefact(self):
+        _, _, rows = self.run_runner()
+        for key in ("input_sha256", "encoder_compressed_sha256",
+                    "decoder_compressed_sha256", "A_output_sha256",
+                    "B_output_sha256"):
+            self.assertEqual(len(rows[0][key]), 64, key)
+
+    def test_runner_processes_multiple_cases(self):
+        second_input = os.path.join(self.temp_dir, "input2.bin")
+        with open(second_input, "wb") as handle:
+            handle.write(bytes((index * 11) % 256 for index in range(1800)))
+
+        cases_path = os.path.join(self.temp_dir, "two_cases.json")
+        write_json_file(cases_path, [
+            build_case("one", self.input_path),
+            build_case("two", second_input, robustness=2, pt=20, ft=50, rt=100),
+        ])
+
+        exit_code, stderr, rows = self.run_runner(cases_path=cases_path)
+        self.assertEqual(exit_code, 0, stderr)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row["case"] for row in rows}, {"one", "two"})
+
+    def test_three_implementations_give_three_unique_pairs(self):
+        config_path = self.write_config_file(entries=[
+            {"name": "impl-a", "executable": self.fake_executable},
+            {"name": "impl-b", "executable": self.fake_executable},
+            {"name": "impl-c", "executable": self.fake_executable},
+        ])
+        exit_code, stderr, rows = self.run_runner(config_path=config_path)
+        self.assertEqual(exit_code, 0, stderr)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            {(row["encoder"], row["decoder"]) for row in rows},
+            {("impl-a", "impl-b"), ("impl-a", "impl-c"), ("impl-b", "impl-c")})
+        for row in rows:
+            for key in ("A_encoder_roundtrip", "B_decoder_roundtrip",
+                        "C_encoder_to_decoder", "D_decoder_to_encoder"):
+                self.assertIsNotNone(row[key])
+
+    def test_results_are_natively_json_serialisable(self):
+        self.run_runner()
+        with open(self.out_json_path) as handle:
+            self.assertIsInstance(json.load(handle), list)
+
+    def test_runs_from_a_different_working_directory(self):
+        """Relative paths resolve against the config and cases files, not the CWD."""
+        config_path = self.write_config_file(entries=[
+            {"name": "impl-a", "executable": "fake_impl.py"},
+            {"name": "impl-b", "executable": "fake_impl.py"},
+        ], name="relative_config.json")
+
+        cases_path = os.path.join(self.temp_dir, "relative_cases.json")
+        write_json_file(cases_path, [build_case("relative", "input.bin")])
+
+        other_directory = tempfile.mkdtemp(prefix="ccsds124-cwd-")
+        self.addCleanup(shutil.rmtree, other_directory, ignore_errors=True)
+
+        process = subprocess.run([
+            sys.executable, os.path.join(RUNNER_DIR, "run_correctness.py"),
+            "--config", config_path, "--cases", cases_path,
+            "--workdir", self.workdir, "--out-json", self.out_json_path,
+        ], capture_output=True, text=True, cwd=other_directory, timeout=60)
+
+        self.assertEqual(process.returncode, 0, process.stderr)
+        self.assertTrue(read_json_file(self.out_json_path)[0]["A_encoder_roundtrip"])
+
+    def test_paths_containing_spaces(self):
+        spaced_directory = os.path.join(self.temp_dir, "dir with spaces")
+        os.makedirs(spaced_directory, exist_ok=True)
+        spaced_input = os.path.join(spaced_directory, "in put.bin")
+        shutil.copy(self.input_path, spaced_input)
+
+        cases_path = os.path.join(spaced_directory, "ca ses.json")
+        write_json_file(cases_path, [build_case("spaced", spaced_input)])
+
+        exit_code, stderr, rows = self.run_runner(cases_path=cases_path)
+        self.assertEqual(exit_code, 0, stderr)
+        self.assertTrue(rows[0]["A_encoder_roundtrip"])
+
+
+class TestStaleArtefacts(RunnerTestBase):
+    """A run that produces nothing must never reuse a previous run's files."""
+
+    def test_missing_json_is_not_satisfied_by_a_previous_run(self):
+        first_code, _, _ = self.run_runner()
+        self.assertEqual(first_code, 0)
+
+        second_code, _, rows = self.run_runner(environment={"FAKE_MODE": "no_json"})
+        self.assertEqual(second_code, 1)
+        self.assertIn("produced no JSON", rows[0]["encoder_compress_error"])
+
+    def test_missing_output_is_not_satisfied_by_a_previous_run(self):
+        first_code, _, _ = self.run_runner()
+        self.assertEqual(first_code, 0)
+
+        second_code, _, rows = self.run_runner(environment={"FAKE_MODE": "no_output"})
+        self.assertEqual(second_code, 1)
+        self.assertIn("no output written", rows[0]["encoder_compress_error"])
+        self.assertIsNone(rows[0]["encoder_compressed_bytes"])
+
+
+class TestArtefactLayout(RunnerTestBase):
+    def test_names_that_would_collide_when_concatenated_stay_separate(self):
+        """("a-vs-b", "c") and ("a", "b-vs-c") must not share a directory.
+
+        Both are valid names, and joining them into a single tag would produce
+        "a-vs-b-vs-c" for either pair. Nesting keeps them apart.
+        """
+        config_path = self.write_config_file(entries=[
+            {"name": "a-vs-b", "executable": self.fake_executable},
+            {"name": "c", "executable": self.fake_executable},
+            {"name": "a", "executable": self.fake_executable},
+            {"name": "b-vs-c", "executable": self.fake_executable},
+        ])
+
+        exit_code, stderr, rows = self.run_runner(config_path=config_path)
+        self.assertEqual(exit_code, 0, stderr)
+
+        # Four implementations give six unique pairs.
+        self.assertEqual(len(rows), 6)
+        pairs = {(row["encoder"], row["decoder"]) for row in rows}
+        self.assertEqual(len(pairs), 6)
+        self.assertIn(("a-vs-b", "c"), pairs)
+        self.assertIn(("a", "b-vs-c"), pairs)
+
+        # No result was overwritten: every pair kept its own artefacts.
+        for row in rows:
+            self.assertTrue(row["A_encoder_roundtrip"])
+            self.assertIsNotNone(row["encoder_compressed_sha256"])
+
+        first = os.path.join(self.workdir, "fixture", "a-vs-b", "c")
+        second = os.path.join(self.workdir, "fixture", "a", "b-vs-c")
+        self.assertTrue(os.path.isdir(first))
+        self.assertTrue(os.path.isdir(second))
+        self.assertNotEqual(os.path.realpath(first), os.path.realpath(second))
+
+        # Every artefact stays under the work directory.
+        root = os.path.realpath(self.workdir)
+        for directory, _, filenames in os.walk(root):
+            for filename in filenames:
+                path = os.path.realpath(os.path.join(directory, filename))
+                self.assertTrue(path.startswith(root + os.sep), path)
+
+
+class TestOutputPathErrors(RunnerTestBase):
+    def test_workdir_is_an_existing_file(self):
+        blocking_file = os.path.join(self.temp_dir, "not-a-directory")
+        with open(blocking_file, "w") as handle:
+            handle.write("")
+
+        exit_code, stderr, _ = self.run_runner(workdir=blocking_file)
+        self.assertEqual(exit_code, 2)
+        self.assertNotIn("Traceback", stderr)
+        self.assertIn("workdir", stderr)
+
+    def test_out_json_parent_is_a_file(self):
+        blocking_file = os.path.join(self.temp_dir, "blocking")
+        with open(blocking_file, "w") as handle:
+            handle.write("")
+        self.out_json_path = os.path.join(blocking_file, "out.json")
+
+        exit_code, stderr, _ = self.run_runner()
+        self.assertEqual(exit_code, 2)
+        self.assertNotIn("Traceback", stderr)
+        self.assertIn("cannot write", stderr)
+
+
+class TestExecutionContract(RunnerTestBase):
+    def test_exit_zero_and_rc_zero_succeeds(self):
+        exit_code, _, rows = self.run_runner()
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(rows[0]["encoder_process_exit_code"], 0)
+        self.assertEqual(rows[0]["encoder_implementation_rc"], 0)
+
+    def test_exit_zero_but_rc_nonzero_fails(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "rc_nonzero_exit_zero"})
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(rows[0]["encoder_process_exit_code"], 0)
+        self.assertEqual(rows[0]["encoder_implementation_rc"], 5)
+        self.assertFalse(rows[0]["A_encoder_roundtrip"])
+
+    def test_exit_nonzero_but_rc_zero_is_flagged_inconsistent(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "exit_nonzero_rc_zero"})
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(rows[0]["encoder_process_exit_code"], 4)
+        self.assertEqual(rows[0]["encoder_implementation_rc"], 0)
+        self.assertIn("inconsistent status", rows[0]["encoder_compress_error"])
+
+    def test_both_nonzero_keeps_both_codes(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "both_nonzero"})
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(rows[0]["encoder_process_exit_code"], 4)
+        self.assertEqual(rows[0]["encoder_implementation_rc"], 9)
+
+    def test_declared_mode_must_match_invocation(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "bad_mode"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("is not one of", rows[0]["encoder_compress_error"])
+
+    def test_declared_input_bytes_must_match_disk(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "wrong_input_bytes"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("declared input_bytes", rows[0]["encoder_compress_error"])
+
+    def test_declared_output_bytes_must_match_disk(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "wrong_output_bytes"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("declared output_bytes", rows[0]["encoder_compress_error"])
+
+    def test_missing_output_with_rc_zero_fails(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "no_output"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("no output written", rows[0]["encoder_compress_error"])
+
+    def test_invalid_json_is_detected(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "bad_json"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("invalid JSON", rows[0]["encoder_compress_error"])
+
+    def test_missing_required_keys_detected(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "missing_keys"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("missing required field", rows[0]["encoder_compress_error"])
+
+    def test_wrong_field_types_detected(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "wrong_types"})
+        self.assertEqual(exit_code, 1)
+        message = rows[0]["encoder_compress_error"]
+        self.assertIn("'rc' must be an integer", message)
+        self.assertIn("'output_bytes' must be >= 0", message)
+
+    def test_error_field_must_be_a_string(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "bad_error_type"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("'error' must be a string", rows[0]["encoder_compress_error"])
+
+    def test_reported_impl_must_not_be_empty(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "empty_impl"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("'impl' must not be empty", rows[0]["encoder_compress_error"])
+
+    def test_absent_json_detected(self):
+        exit_code, _, rows = self.run_runner(environment={"FAKE_MODE": "no_json"})
+        self.assertEqual(exit_code, 1)
+        self.assertIn("produced no JSON", rows[0]["encoder_compress_error"])
+
+    def test_encoder_error_is_surfaced(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "compress_error"})
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(rows[0]["encoder_implementation_rc"], 7)
+
+    def test_missing_executable(self):
+        config_path = self.write_config_file(entries=[
+            {"name": "impl-a", "executable": os.path.join(self.temp_dir, "absent")},
+            {"name": "impl-b", "executable": self.fake_executable},
+        ])
+        exit_code, _, rows = self.run_runner(config_path=config_path)
+        self.assertEqual(exit_code, 1)
+        self.assertIn("not found", rows[0]["encoder_compress_error"])
+
+    def test_timeout_only_blocks_the_targeted_implementation(self):
+        hanging = os.path.join(self.temp_dir, "hanging.py")
+        write_env_wrapper(hanging, self.fake_executable, {"FAKE_MODE": "hang"})
+        config_path = self.write_config_file(entries=[
+            {"name": "impl-a", "executable": self.fake_executable},
+            {"name": "impl-b", "executable": hanging, "timeout": 1},
+        ])
+
+        started = time.monotonic()
+        exit_code, _, rows = self.run_runner(config_path=config_path)
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("timeout", rows[0]["decoder_compress_error"])
+        self.assertLess(elapsed, 20, "the healthy implementation must not hang")
+
+
+class TestRoundTripStrictness(RunnerTestBase):
+    def test_wrong_reconstruction_fails(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "bad_decompress"})
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(rows[0]["A_encoder_roundtrip"])
+
+    def test_one_extra_zero_byte_fails(self):
+        exit_code, _, rows = self.run_runner(
+            environment={"FAKE_MODE": "extra_zero_byte"})
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(rows[0]["A_encoder_roundtrip"])
+
+
+class TestBitIdentityStates(RunnerTestBase):
+    def test_true_when_both_streams_present_and_equal(self):
+        _, _, rows = self.run_runner()
+        self.assertIs(rows[0]["E_bit_identical"], True)
+        self.assertEqual(rows[0]["E_detail"], "")
+
+    def test_false_when_both_streams_present_and_different(self):
+        divergent = os.path.join(self.temp_dir, "divergent.py")
+        write_env_wrapper(divergent, self.fake_executable, {"FAKE_KEY": "255"})
+        config_path = self.write_config_file(entries=[
+            {"name": "impl-a", "executable": self.fake_executable},
+            {"name": "impl-b", "executable": divergent},
+        ])
+
+        exit_code, _, rows = self.run_runner(config_path=config_path)
+        row = rows[0]
+        self.assertIs(row["E_bit_identical"], False)
+        self.assertIsNotNone(row["E_first_difference"])
+        self.assertTrue(row["A_encoder_roundtrip"])
+        self.assertTrue(row["B_decoder_roundtrip"])
+        # Cross decoding uses the other key, so the reconstruction is wrong.
+        self.assertFalse(row["C_encoder_to_decoder"])
+        self.assertEqual(exit_code, 1)
+
+    def test_null_when_a_stream_was_never_produced(self):
+        _, _, rows = self.run_runner(environment={"FAKE_MODE": "no_output"})
+        self.assertIsNone(rows[0]["E_bit_identical"])
+        self.assertIsNone(rows[0]["E_first_difference"])
+        self.assertIn("not produced", rows[0]["E_detail"])
+
+
+class TestConfigurationValidation(RunnerTestBase):
+    def assert_usage_error(self, entries=None, raw_config=None, extra_args=()):
+        config_path = os.path.join(self.temp_dir, "invalid.json")
+        if raw_config is None:
+            raw_config = {"implementations": entries}
+        write_json_file(config_path, raw_config)
+
+        exit_code, stderr, _ = self.run_runner(config_path=config_path,
+                                               extra_args=extra_args)
+        self.assertEqual(exit_code, 2)
+        self.assertNotIn("Traceback", stderr)
+        self.assertTrue(stderr.startswith("error:"), stderr)
+        return stderr
+
+    def test_root_is_a_list(self):
+        self.assert_usage_error(raw_config=[{"name": "a"}])
+
+    def test_implementations_is_not_a_list(self):
+        self.assert_usage_error(raw_config={"implementations": "impl-a"})
+
+    def test_implementation_entry_is_not_an_object(self):
+        self.assert_usage_error(entries=["impl-a", "impl-b"])
+
+    def test_single_implementation(self):
+        self.assert_usage_error(
+            entries=[{"name": "only", "executable": self.fake_executable}])
+
+    def test_missing_executable_key(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a"},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_empty_executable(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": ""},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_extra_args_is_a_string(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable,
+             "extra_args": "--flag"},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_extra_args_contains_a_non_string(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable,
+             "extra_args": ["--flag", 3]},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_zero_timeout(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable, "timeout": 0},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_negative_timeout(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable, "timeout": -1},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_boolean_timeout(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable, "timeout": True},
+            {"name": "impl-b", "executable": self.fake_executable}])
+
+    def test_global_timeout_must_be_positive(self):
+        self.assert_usage_error(entries=[
+            {"name": "impl-a", "executable": self.fake_executable},
+            {"name": "impl-b", "executable": self.fake_executable}],
+            extra_args=("--timeout", "0"))
+
+    def test_duplicate_implementation_names(self):
+        stderr = self.assert_usage_error(entries=[
+            {"name": "same", "executable": self.fake_executable},
+            {"name": "same", "executable": self.fake_executable}])
+        self.assertIn("unique", stderr)
+
+    def test_unsafe_implementation_names(self):
+        for unsafe in ("../escape", "/tmp/escape", "a/b", "", "."):
+            with self.subTest(name=unsafe):
+                self.assert_usage_error(entries=[
+                    {"name": unsafe, "executable": self.fake_executable},
+                    {"name": "impl-b", "executable": self.fake_executable}])
+
+
+class TestCaseValidation(RunnerTestBase):
+    def assert_case_error(self, cases):
+        cases_path = os.path.join(self.temp_dir, "invalid_cases.json")
+        write_json_file(cases_path, cases)
+
+        exit_code, stderr, _ = self.run_runner(cases_path=cases_path)
+        self.assertEqual(exit_code, 2)
+        self.assertNotIn("Traceback", stderr)
+        self.assertTrue(stderr.startswith("error:"), stderr)
+        return stderr
+
+    def test_cases_file_is_not_a_list(self):
+        self.assert_case_error({"name": "not-a-list"})
+
+    def test_cases_file_is_empty(self):
+        self.assert_case_error([])
+
+    def test_case_is_not_an_object(self):
+        self.assert_case_error(["fixture"])
+
+    def test_missing_input(self):
+        self.assert_case_error([build_case("nope", "/nonexistent/file.bin")])
+
+    def test_input_is_a_directory(self):
+        self.assert_case_error([build_case("dir", self.temp_dir)])
+
+    def test_input_size_is_not_a_multiple_of_packet_bytes(self):
+        stderr = self.assert_case_error(
+            [build_case("odd", self.input_path, packet_bytes=7)])
+        self.assertIn("multiple of", stderr)
+
+    def test_packet_bytes_must_be_positive(self):
+        self.assert_case_error(
+            [build_case("zero", self.input_path, packet_bytes=0)])
+
+    def test_robustness_out_of_range(self):
+        self.assert_case_error([build_case("bad-r", self.input_path, robustness=8)])
+
+    def test_robustness_must_not_be_boolean(self):
+        self.assert_case_error([build_case("bool-r", self.input_path, robustness=True)])
+
+    def test_period_must_be_an_integer(self):
+        self.assert_case_error([build_case("bad-pt", self.input_path, pt="ten")])
+
+    def test_duplicate_case_names(self):
+        stderr = self.assert_case_error([
+            build_case("twice", self.input_path),
+            build_case("twice", self.input_path),
+        ])
+        self.assertIn("duplicate case name", stderr)
+
+    def test_unsafe_case_names(self):
+        for unsafe in ("../escape", "/tmp/escape", "a/b", "", ".."):
+            with self.subTest(name=unsafe):
+                self.assert_case_error([build_case(unsafe, self.input_path)])
+
+    def test_no_artefact_escapes_the_workdir(self):
+        """Unsafe names are rejected before any artefact can be written."""
+        outside = os.path.join(self.temp_dir, "outside")
+        os.makedirs(outside, exist_ok=True)
+        self.assert_case_error([build_case("../outside/escape", self.input_path)])
+        self.assertEqual(os.listdir(outside), [])
+
+
+class TestSchemaAgreement(unittest.TestCase):
+    def test_schema_file_and_code_agree(self):
+        """The JSON schema must not drift from the checks enforced in code."""
+        schema_path = os.path.join(RUNNER_DIR, "schemas", "result.schema.json")
+        schema = read_json_file(schema_path)
+
+        self.assertEqual(sorted(schema["required"]),
+                         sorted(run_correctness.REQUIRED_RESULT_FIELDS))
+
+        json_to_python = {"string": str, "integer": int}
+        for field, expected_type in run_correctness.REQUIRED_RESULT_FIELDS.items():
+            declared = schema["properties"][field]["type"]
+            self.assertEqual(json_to_python[declared], expected_type,
+                             f"schema and code disagree on type of '{field}'")
+
+        self.assertEqual(tuple(schema["properties"]["mode"]["enum"]),
+                         run_correctness.VALID_MODES)
+
+        # The minimums the schema advertises are the ones the code enforces.
+        for field in ("input_bytes", "output_bytes"):
+            self.assertEqual(schema["properties"][field]["minimum"], 0)
+        self.assertEqual(schema["properties"]["impl"]["minLength"], 1)
+
+    def test_schema_declares_no_unconsumed_field(self):
+        """Every documented field is one the runner actually reads."""
+        schema_path = os.path.join(RUNNER_DIR, "schemas", "result.schema.json")
+        schema = read_json_file(schema_path)
+        consumed = set(run_correctness.REQUIRED_RESULT_FIELDS) | {"error"}
+        self.assertEqual(set(schema["properties"]), consumed)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Add a process-based runner for pairwise interoperability testing.
- Check both self round-trips, both cross-decoding directions, and compressed-stream byte identity.
- Keep process exit codes separate from implementation return codes.
- Validate wrapper output against the files produced on disk.
- Prevent stale artefacts and unsafe names from affecting results.

## Scope

This covers the correctness and interoperability part of #48.

Performance, memory use, and binary-size comparisons remain out of scope for this change.

The runner complements `crossvalidation/run_crossvalidation.sh`: the existing script validates an implementation against the UAB/CNES expected outputs, while this runner compares multiple implementations against each other on user-provided inputs.

## Verification

- `python3 -m unittest discover -s crossvalidation/interoperability/tests -v` — 75 tests passed
- `python3 -m compileall crossvalidation/interoperability`
- `python3 crossvalidation/interoperability/run_correctness.py --help`
- `make -C implementations/c test`
- `git diff --check`

The test suite uses deterministic fake implementations and requires no network or external binary.
